### PR TITLE
Disable allow_abbrev from Python scripts using argparse

### DIFF
--- a/scripts/generate_psa_wrappers.py
+++ b/scripts/generate_psa_wrappers.py
@@ -252,7 +252,8 @@ DEFAULT_C_OUTPUT_FILE_NAME = 'tests/src/psa_test_wrappers.c'
 DEFAULT_H_OUTPUT_FILE_NAME = 'tests/include/test/psa_test_wrappers.h'
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description=globals()['__doc__'])
+    parser = argparse.ArgumentParser(description=globals()['__doc__'],
+                                     allow_abbrev=False)
     parser.add_argument('--log',
                         help='Stream to log to (default: no logging code)')
     parser.add_argument('--output-c',

--- a/scripts/generate_test_cert_macros.py
+++ b/scripts/generate_test_cert_macros.py
@@ -52,7 +52,7 @@ INPUT_ARGS = [
 ]
 
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     default_output_path = os.path.join(TEST_DIR, 'src', 'test_certs.h')
     parser.add_argument('--output', type=str, default=default_output_path)
     parser.add_argument('--list-dependencies', action='store_true')

--- a/scripts/generate_test_code.py
+++ b/scripts/generate_test_code.py
@@ -1204,7 +1204,8 @@ def main():
     :return:
     """
     parser = argparse.ArgumentParser(
-        description='Dynamically generate test suite code.')
+        description='Dynamically generate test suite code.',
+        allow_abbrev=False)
 
     parser.add_argument("-f", "--functions-file",
                         dest="funcs_file",

--- a/scripts/generate_test_keys.py
+++ b/scripts/generate_test_keys.py
@@ -170,7 +170,7 @@ def collect_keys() -> Tuple[str, str]:
 def main() -> None:
     default_output_path = guess_project_root() + "/tests/src/test_keys.h"
 
-    argparser = argparse.ArgumentParser()
+    argparser = argparse.ArgumentParser(allow_abbrev=False)
     argparser.add_argument("--output", help="Output file", default=default_output_path)
     args = argparser.parse_args()
 

--- a/scripts/mbedtls_framework/test_data_generation.py
+++ b/scripts/mbedtls_framework/test_data_generation.py
@@ -178,7 +178,8 @@ class TestGenerator:
 
 def main(args, description: str, generator_class: Type[TestGenerator] = TestGenerator):
     """Command line entry point."""
-    parser = argparse.ArgumentParser(description=description)
+    parser = argparse.ArgumentParser(description=description,
+                                     allow_abbrev=False)
     parser.add_argument('--list', action='store_true',
                         help='List available targets and exit')
     parser.add_argument('--list-for-cmake', action='store_true',


### PR DESCRIPTION
Python's argparse library, by default, allows shortening of command line arguments. This can introduce silent failures when shortened commands are used and another command is added to the script which uses that name.

This change was requested on https://github.com/Mbed-TLS/mbedtls/pull/9294