### PR TITLE
Adapt to the move of crypto test suites to tf-psa-crypto directory

### DIFF
--- a/scripts/mbedtls_framework/psa_information.py
+++ b/scripts/mbedtls_framework/psa_information.py
@@ -37,11 +37,12 @@ class Information:
         if os.path.isdir('tf-psa-crypto'):
             header_file_names = ['tf-psa-crypto/include/psa/crypto_values.h',
                                  'tf-psa-crypto/include/psa/crypto_extra.h']
+            test_suites = ['tf-psa-crypto/tests/suites/test_suite_psa_crypto_metadata.data']
         else:
             header_file_names = ['include/psa/crypto_values.h',
                                  'include/psa/crypto_extra.h']
+            test_suites = ['tests/suites/test_suite_psa_crypto_metadata.data']
 
-        test_suites = ['tests/suites/test_suite_psa_crypto_metadata.data']
         for header_file_name in header_file_names:
             constructors.parse_header(header_file_name)
         for test_cases in test_suites:

--- a/scripts/mbedtls_framework/psa_storage.py
+++ b/scripts/mbedtls_framework/psa_storage.py
@@ -53,6 +53,11 @@ class Expr:
 
         if build_tree.looks_like_tf_psa_crypto_root('.'):
             includes.append('drivers/builtin/include')
+            # Temporary, while TF-PSA-Crypto build system in Mbed TLS still
+            # reference some files in Mbed TLS include directory. When it does
+            # not anymore, this can be removed.
+            if build_tree.looks_like_mbedtls_root('..'):
+                includes.append('../include')
         values = c_build_helper.get_c_expression_values(
             'unsigned long', '%lu',
             expressions,


### PR DESCRIPTION
Due to the move of crypto test suites to tf-psa-crypto directory in development, adapt the path to test_suite_psa_crypto_metadata.data and a list of include paths.
Companion PR of https://github.com/Mbed-TLS/mbedtls/pull/9394.
3.6 PR: https://github.com/Mbed-TLS/mbedtls/pull/9419