### PR TITLE
Projects and Mbed TLS 3.6 detection

### DIFF
--- a/scripts/mbedtls_framework/build_tree.py
+++ b/scripts/mbedtls_framework/build_tree.py
@@ -130,12 +130,15 @@ def guess_tf_psa_crypto_root(root: Optional[str] = None) -> str:
     else:
         raise Exception('TF-PSA-Crypto source tree not found')
 
-def is_mbedtls_3_6_branch(root: Optional[str] = None) -> bool:
-    """Whether root is the root directory of the Mbed TLS 3.6 branch """
-    if root is None:
-        root = os.getcwd()
+def is_mbedtls_3_6() -> bool:
+    """Whether the working tree is an Mbed TLS 3.6 one or not
+
+    Return false in we are in TF-PSA-Crypto or in Mbed TLS but with a version
+    different from 3.6.x.
+    Raise an exception if we are neither in Mbed TLS nor in TF-PSA-Crypto.
+    """
+    root = guess_project_root()
     if not looks_like_mbedtls_root(root):
         return False
     with open(os.path.join(root, 'include', 'mbedtls', 'build_info.h'), 'r') as f:
-        pattern = re.compile("#define MBEDTLS_VERSION_NUMBER.*0x0306")
-        return pattern.search(f.read()) is not None
+        return re.search(r"#define MBEDTLS_VERSION_NUMBER.*0x0306", f.read()) is not None

--- a/scripts/mbedtls_framework/build_tree.py
+++ b/scripts/mbedtls_framework/build_tree.py
@@ -11,13 +11,19 @@ from typing import Optional
 
 def looks_like_tf_psa_crypto_root(path: str) -> bool:
     """Whether the given directory looks like the root of the PSA Crypto source tree."""
-    return all(os.path.isdir(os.path.join(path, subdir))
-               for subdir in ['include', 'core', 'drivers', 'programs', 'tests'])
+    try:
+        with open(os.path.join(path, 'scripts', 'project_name.txt'), 'r') as f:
+            return f.read() == "TF-PSA-Crypto\n"
+    except FileNotFoundError:
+        return False
 
 def looks_like_mbedtls_root(path: str) -> bool:
     """Whether the given directory looks like the root of the Mbed TLS source tree."""
-    return all(os.path.isdir(os.path.join(path, subdir))
-               for subdir in ['include', 'library', 'programs', 'tests'])
+    try:
+        with open(os.path.join(path, 'scripts', 'project_name.txt'), 'r') as f:
+            return f.read() == "Mbed TLS\n"
+    except FileNotFoundError:
+        return False
 
 def looks_like_root(path: str) -> bool:
     return looks_like_tf_psa_crypto_root(path) or looks_like_mbedtls_root(path)

--- a/scripts/mbedtls_framework/build_tree.py
+++ b/scripts/mbedtls_framework/build_tree.py
@@ -7,6 +7,7 @@
 
 import os
 import inspect
+import re
 from typing import Optional
 
 def looks_like_tf_psa_crypto_root(path: str) -> bool:
@@ -128,3 +129,13 @@ def guess_tf_psa_crypto_root(root: Optional[str] = None) -> str:
         return root
     else:
         raise Exception('TF-PSA-Crypto source tree not found')
+
+def is_mbedtls_3_6_branch(root: Optional[str] = None) -> bool:
+    """Whether root is the root directory of the Mbed TLS 3.6 branch """
+    if root is None:
+        root = os.getcwd()
+    if not looks_like_mbedtls_root(root):
+        return False
+    with open(os.path.join(root, 'include', 'mbedtls', 'build_info.h'), 'r') as f:
+        pattern = re.compile("#define MBEDTLS_VERSION_NUMBER.*0x0306")
+        return pattern.search(f.read()) is not None


### PR DESCRIPTION
Changes to build_tree.py to use project_name.txt to detect between Mbed TLS and TF-PSA-Crypto and to detect an Mbed TLS 3.6 working tree.
Companion of https://github.com/Mbed-TLS/mbedtls/pull/9552.