### PR TITLE
Support crypto config usage in `depends.py`

### DIFF
--- a/scripts/mbedtls_framework/c_build_helper.py
+++ b/scripts/mbedtls_framework/c_build_helper.py
@@ -11,6 +11,15 @@ import subprocess
 import sys
 import tempfile
 
+class CompileError(Exception):
+    """Excetion to represent an error during the compilation."""
+
+    def __init__(self, message):
+        """Save the error massage"""
+
+        super().__init__()
+        self.message = message
+
 def remove_file_if_exists(filename):
     """Remove the specified file, ignoring errors."""
     if not filename:
@@ -107,7 +116,13 @@ def compile_c_file(c_filename, exe_filename, include_dirs):
     else:
         cmd += ['-o' + exe_filename]
 
-    subprocess.check_call(cmd + [c_filename])
+    try:
+        subprocess.check_output(cmd + [c_filename],
+                                stderr=subprocess.PIPE,
+                                universal_newlines=True)
+
+    except subprocess.CalledProcessError as e:
+        raise CompileError(e.stderr) from e
 
 def get_c_expression_values(
         cast_to, printf_format,

--- a/scripts/mbedtls_framework/c_build_helper.py
+++ b/scripts/mbedtls_framework/c_build_helper.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 
 class CompileError(Exception):
-    """Excetion to represent an error during the compilation."""
+    """Exception to represent an error during the compilation."""
 
     def __init__(self, message):
         """Save the error massage"""

--- a/scripts/mbedtls_framework/config_common.py
+++ b/scripts/mbedtls_framework/config_common.py
@@ -8,6 +8,7 @@
 import argparse
 import os
 import re
+import shutil
 import sys
 
 from abc import ABCMeta
@@ -194,6 +195,18 @@ class Config:
 
         return self._get_configfile(name).filename
 
+    def backup(self, suffix='.bak'):
+        """Back up the configuration file."""
+
+        for configfile in self.configfiles:
+            configfile.backup(suffix)
+
+    def restore(self):
+        """Restore the configuration file."""
+
+        for configfile in self.configfiles:
+            configfile.restore()
+
 
 class ConfigFile(metaclass=ABCMeta):
     """Representation of a configuration file."""
@@ -214,6 +227,8 @@ class ConfigFile(metaclass=ABCMeta):
         self.current_section = None
         self.inclusion_guard = None
         self.modified = False
+        self._backupname = None
+        self._own_backup = False
 
     _define_line_regexp = (r'(?P<indentation>\s*)' +
                            r'(?P<commented_out>(//\s*)?)' +
@@ -323,6 +338,37 @@ class ConfigFile(metaclass=ABCMeta):
 
         with open(filename, 'w', encoding='utf-8') as output:
             self.write_to_stream(settings, output)
+
+    def backup(self, suffix='.bak'):
+        """Back up the configuration file.
+
+        If the backup file already exists, it is presumed to be the desired backup,
+        so don't make another backup.
+        """
+        if self._backupname:
+            return
+
+        self._backupname = self.filename + suffix
+        if os.path.exists(self._backupname):
+            self._own_backup = False
+        else:
+            self._own_backup = True
+            shutil.copy(self.filename, self._backupname)
+
+    def restore(self):
+        """Restore the configuration file.
+
+        Only delete the backup file if it was created earlier.
+        """
+        if not self._backupname:
+            return
+
+        if self._own_backup:
+            shutil.move(self._backupname, self.filename)
+        else:
+            shutil.copy(self._backupname, self.filename)
+
+        self._backupname = None
 
 
 class ConfigTool(metaclass=ABCMeta):


### PR DESCRIPTION
To support the `depnds.py` update:
* Move config file backup functionality to `config_common.py`
* Capture output of C file building process to support consistency check

Related to https://github.com/Mbed-TLS/mbedtls/pull/9292