### PR TITLE
enhance common_config.py and generate_test_code.py

### DIFF
--- a/scripts/generate_test_code.py
+++ b/scripts/generate_test_code.py
@@ -209,6 +209,10 @@ CONDITION_VALUE_REGEX = r'[\d|\w|\(][\s_\(\)0-9a-zA-Z\+\-\*\/]*'
 CONDITION_REGEX = r'({})(?:\s*({})\s*({}))?$'.format(C_IDENTIFIER_REGEX,
                                                      CONDITION_OPERATOR_REGEX,
                                                      CONDITION_VALUE_REGEX)
+# Match numerical values that start with a 0 because they can be accidentally
+# octal or accidentally decimal. Hexadecimal values starting with '0x' are
+# valid of course.
+INVALID_NUMBER_FORMAT_REGEX = r'(0[0-9]+)'
 TEST_FUNCTION_VALIDATION_REGEX = r'\s*void\s+(?P<func_name>\w+)\s*\('
 FUNCTION_ARG_LIST_END_REGEX = r'.*\)'
 EXIT_LABEL_REGEX = r'^exit:'
@@ -407,6 +411,8 @@ def validate_dependency(dependency):
     :return: input dependency stripped of leading & trailing white spaces.
     """
     dependency = dependency.strip()
+    if re.match(INVALID_NUMBER_FORMAT_REGEX, dependency, re.I):
+        raise GeneratorInputError('Invalid numerical format %s' % dependency)
     if not re.match(CONDITION_REGEX, dependency, re.I):
         raise GeneratorInputError('Invalid dependency %s' % dependency)
     return dependency

--- a/scripts/generate_test_code.py
+++ b/scripts/generate_test_code.py
@@ -213,7 +213,7 @@ CONDITION_REGEX = r'({})(?:\s*({})\s*({}))?$'.format(C_IDENTIFIER_REGEX,
 # Match numerical values that start with a 0 because they can be accidentally
 # octal or accidentally decimal. Hexadecimal values starting with '0x' are
 # valid of course.
-INVALID_NUMBER_FORMAT_REGEX = r'(0[0-9]+)'
+AMBIGUOUS_INTEGER_REGEX = r'\b0[0-9]+'
 TEST_FUNCTION_VALIDATION_REGEX = r'\s*void\s+(?P<func_name>\w+)\s*\('
 FUNCTION_ARG_LIST_END_REGEX = r'.*\)'
 EXIT_LABEL_REGEX = r'^exit:'
@@ -412,8 +412,9 @@ def validate_dependency(dependency):
     :return: input dependency stripped of leading & trailing white spaces.
     """
     dependency = dependency.strip()
-    if re.match(INVALID_NUMBER_FORMAT_REGEX, dependency, re.I):
-        raise GeneratorInputError('Invalid numerical format %s' % dependency)
+    m = re.search(AMBIGUOUS_INTEGER_REGEX, dependency)
+    if m:
+        raise GeneratorInputError('Ambiguous integer literal: '+ m.group(0))
     if not re.match(CONDITION_REGEX, dependency, re.I):
         raise GeneratorInputError('Invalid dependency %s' % dependency)
     return dependency

--- a/scripts/generate_test_code.py
+++ b/scripts/generate_test_code.py
@@ -193,10 +193,19 @@ BEGIN_CASE_REGEX = r'/\*\s*BEGIN_CASE\s*(?P<depends_on>.*?)\s*\*/'
 END_CASE_REGEX = r'/\*\s*END_CASE\s*\*/'
 
 DEPENDENCY_REGEX = r'depends_on:(?P<dependencies>.*)'
+# This can be something like [!]MBEDTLS_xxx
 C_IDENTIFIER_REGEX = r'!?[a-z_][a-z0-9_]*'
+# This is a generic relation operator: ==, !=, >[=], <[=]
 CONDITION_OPERATOR_REGEX = r'[!=]=|[<>]=?'
-# forbid 0ddd which might be accidentally octal or accidentally decimal
-CONDITION_VALUE_REGEX = r'[-+]?(0x[0-9a-f]+|0|[1-9][0-9]*)'
+# This can be (almost) anything as long as:
+# - it starts with a number or a letter or a "("
+# - it contains only
+#       - numbers
+#       - letters
+#       - spaces
+#       - math operators, i.e "+"", "-", "*", "/"
+#       - parentheses, i.e. "()"
+CONDITION_VALUE_REGEX = r'[\d|\w|\(][\s_\(\)0-9a-zA-Z\+\-\*\/]*'
 CONDITION_REGEX = r'({})(?:\s*({})\s*({}))?$'.format(C_IDENTIFIER_REGEX,
                                                      CONDITION_OPERATOR_REGEX,
                                                      CONDITION_VALUE_REGEX)

--- a/scripts/generate_test_code.py
+++ b/scripts/generate_test_code.py
@@ -206,7 +206,7 @@ CONDITION_OPERATOR_REGEX = r'[!=]=|[<>]=?'
 #       - math operators, i.e "+", "-", "*", "/"
 #       - bitwise operators, i.e. "^", "|", "&", "~", "<<", ">>"
 #       - parentheses, i.e. "()"
-CONDITION_VALUE_REGEX = r'[\d|\w|\(][\s_\(\)0-9a-zA-Z\+\-\*\/\^\|\&\~\<\>]*'
+CONDITION_VALUE_REGEX = r'[\w|\(][\s\w\(\)\+\-\*\/\^\|\&\~\<\>]*'
 CONDITION_REGEX = r'({})(?:\s*({})\s*({}))?$'.format(C_IDENTIFIER_REGEX,
                                                      CONDITION_OPERATOR_REGEX,
                                                      CONDITION_VALUE_REGEX)

--- a/scripts/generate_test_code.py
+++ b/scripts/generate_test_code.py
@@ -203,9 +203,10 @@ CONDITION_OPERATOR_REGEX = r'[!=]=|[<>]=?'
 #       - numbers
 #       - letters
 #       - spaces
-#       - math operators, i.e "+"", "-", "*", "/"
+#       - math operators, i.e "+", "-", "*", "/"
+#       - bitwise operators, i.e. "^", "|", "&", "~", "<<", ">>"
 #       - parentheses, i.e. "()"
-CONDITION_VALUE_REGEX = r'[\d|\w|\(][\s_\(\)0-9a-zA-Z\+\-\*\/]*'
+CONDITION_VALUE_REGEX = r'[\d|\w|\(][\s_\(\)0-9a-zA-Z\+\-\*\/\^\|\&\~\<\>]*'
 CONDITION_REGEX = r'({})(?:\s*({})\s*({}))?$'.format(C_IDENTIFIER_REGEX,
                                                      CONDITION_OPERATOR_REGEX,
                                                      CONDITION_VALUE_REGEX)

--- a/scripts/mbedtls_framework/config_common.py
+++ b/scripts/mbedtls_framework/config_common.py
@@ -435,12 +435,10 @@ class ConfigTool(metaclass=ABCMeta):
             return 0 if args.symbol in config else 1
         elif args.command == 'get-all':
             match_list = config.get_matching(args.regexs, False)
-            if match_list is not None:
-                sys.stdout.write("\n".join(match_list))
+            sys.stdout.write("\n".join(match_list))
         elif args.command == 'get-all-enabled':
             match_list = config.get_matching(args.regexs, True)
-            if match_list is not None:
-                sys.stdout.write("\n".join(match_list))
+            sys.stdout.write("\n".join(match_list))
         elif args.command == 'set':
             if not args.force and args.symbol not in config.settings:
                 sys.stderr.write(

--- a/scripts/mbedtls_framework/config_common.py
+++ b/scripts/mbedtls_framework/config_common.py
@@ -98,14 +98,12 @@ class Config:
     def get_matching(self, regexs, only_enabled):
         """Get all symbols matching one of the regexs."""
         if not regexs:
-            return None
-        match_list = []
+            return
         regex = re.compile('|'.join(regexs))
         for setting in self.settings.values():
             if regex.search(setting.name):
-                if (not only_enabled) or (only_enabled and setting.active):
-                    match_list.append(setting.name)
-        return match_list
+                if setting.active or not only_enabled:
+                    yield setting.name
 
     def __setitem__(self, name, value):
         """If name is known, set its value.


### PR DESCRIPTION
- Extend `common_config.py` adding `get-all` and `get-all-enabled` commands. Both commands use regex expressions to get a list of symbols. The difference between the 2 is that:
    - get-all returns both enabled and commented out symbols while
    - get-all-enabled returns only enabled ones.

- Enhance `generate_test_code.py` allowing more complex expressions to  be used in `depends_on` fields of `*.data` files.

These new features are used in https://github.com/Mbed-TLS/mbedtls/pull/9302 and https://github.com/Mbed-TLS/mbedtls/pull/9448