### PR TITLE
Framework: Split check_test_cases.py and outcome_analysis.py

### DIFF
--- a/scripts/check_test_cases.py
+++ b/scripts/check_test_cases.py
@@ -13,7 +13,6 @@ import argparse
 import re
 import sys
 
-import scripts_path # pylint: disable=unused-import
 from mbedtls_framework import collect_test_cases
 
 

--- a/scripts/check_test_cases.py
+++ b/scripts/check_test_cases.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python3
 
-"""Sanity checks for test data.
-
-This program contains a class for traversing test cases that can be used
-independently of the checks.
-"""
+"""Sanity checks for test data."""
 
 # Copyright The Mbed TLS Contributors
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later

--- a/scripts/mbedtls_framework/collect_test_cases.py
+++ b/scripts/mbedtls_framework/collect_test_cases.py
@@ -9,8 +9,7 @@ import re
 import subprocess
 import sys
 
-import scripts_path # pylint: disable=unused-import
-from mbedtls_framework import build_tree
+from . import build_tree
 
 
 class ScriptOutputError(ValueError):

--- a/scripts/mbedtls_framework/outcome_analysis.py
+++ b/scripts/mbedtls_framework/outcome_analysis.py
@@ -120,7 +120,7 @@ def open_outcome_file(outcome_file: str) -> typing.TextIO:
     elif outcome_file.endswith('.xz'):
         return lzma.open(outcome_file, 'rt', encoding='utf-8')
     else:
-        return open(outcome_file, 'r', encoding='utf-8')
+        return open(outcome_file, 'rt', encoding='utf-8')
 
 def read_outcome_file(outcome_file: str) -> Outcomes:
     """Parse an outcome file and return an outcome collection.

--- a/scripts/mbedtls_framework/outcome_analysis.py
+++ b/scripts/mbedtls_framework/outcome_analysis.py
@@ -16,7 +16,7 @@ import subprocess
 import os
 import typing
 
-import collect_test_cases
+from . import collect_test_cases
 
 
 # `ComponentOutcomes` is a named tuple which is defined as:

--- a/scripts/mbedtls_framework/outcome_analysis.py
+++ b/scripts/mbedtls_framework/outcome_analysis.py
@@ -307,6 +307,10 @@ class DriverVSReference(Task):
                 results.error("uselessly ignored: {}", suite_case)
 
 
+# Set this to False if a consuming branch can't achieve full test coverage
+# in its default CI run.
+FULL_COVERAGE_BY_DEFAULT = True
+
 def main(known_tasks: typing.Dict[str, typing.Type[Task]]) -> None:
     try:
         parser = argparse.ArgumentParser(description=__doc__)
@@ -317,6 +321,11 @@ def main(known_tasks: typing.Dict[str, typing.Type[Task]]) -> None:
                                  'With one or more TASK, run only those. '
                                  'TASK can be the name of a single task or '
                                  'comma/space-separated list of tasks. ')
+        parser.add_argument('--allow-partial-coverage', action='store_false',
+                            dest='full_coverage', default=FULL_COVERAGE_BY_DEFAULT,
+                            help=("Only warn if a test case is skipped in all components" +
+                                  (" (default)" if not FULL_COVERAGE_BY_DEFAULT else "") +
+                                  ". Only used by the 'analyze_coverage' task."))
         parser.add_argument('--list', action='store_true',
                             help='List all available tasks and exit.')
         parser.add_argument('--log-file',
@@ -324,10 +333,10 @@ def main(known_tasks: typing.Dict[str, typing.Type[Task]]) -> None:
                             help='Log file (default: tests/analyze_outcomes.log;'
                                  ' empty means no log file)')
         parser.add_argument('--require-full-coverage', action='store_true',
-                            dest='full_coverage', help="Require all available "
-                            "test cases to be executed and issue an error "
-                            "otherwise. This flag is ignored if 'task' is "
-                            "neither 'all' nor 'analyze_coverage'")
+                            dest='full_coverage', default=FULL_COVERAGE_BY_DEFAULT,
+                            help=("Require all available test cases to be executed" +
+                                  (" (default)" if FULL_COVERAGE_BY_DEFAULT else "") +
+                                  ". Only used by the 'analyze_coverage' task."))
         options = parser.parse_args()
 
         if options.list:


### PR DESCRIPTION
* Move `collect_test_cases.py` (split from `check_test_cases.py`), `check_test_cases.py` and `outcome_analysis.py` (split from `analyze_outcomes.py`) to the framework repository. Prior to the move, all files were made identical in 3.6 and development.
* By default, it is now an error if a test case is not executed, but the calling script can downgrade it back to a warning.
* Quality of life improvement for when outcome analysis fails: the log of outcome analysis will be the `outcome_analysis-analyze_outcomes.log.xz` artifact on the CI. That way you won't have to dig into the classic pipeline view to see the failures.
* Quality of life improvement for when outcome analysis fails: the existing artifact `outcomes.csv.xz` can now be used locally without decompressing it. (This requires a mypy upgrade, done in each consuming branch.)

* development: https://github.com/Mbed-TLS/mbedtls/pull/9668
* 3.6: https://github.com/Mbed-TLS/mbedtls/pull/9669
