### PR TITLE
Add project and branch detection in shell

### DIFF
--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -132,14 +132,8 @@ pre_set_shell_options () {
 }
 
 pre_check_environment () {
-    # For project detection
-    if [[ -d ../include/mbedtls && -r ../framework/scripts/project_detection.sh ]]; then
-        # we're in tf-psa-crypto as a submodule of mbedtls, grab the framework from mbedtls
-        . ../framework/scripts/project_detection.sh
-    else
-        # we're in TF-PSA-Crypto standalone or in mbedtls, use the local framework
-        . framework/scripts/project_detection.sh
-    fi
+
+    source $FRAMEWORK/scripts/project_detection.sh
 
     if in_mbedtls_repo || in_tf_psa_crypto_repo; then :; else
         echo "Must be run from Mbed TLS / TF-PSA-Crypto root" >&2

--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -131,21 +131,14 @@ pre_set_shell_options () {
     set -e -o pipefail -u
 }
 
-# For project detection
-in_mbedtls_repo () {
-    test "$PROJECT_NAME" = "Mbed TLS"
-}
-
-in_tf_psa_crypto_repo () {
-    test "$PROJECT_NAME" = "TF-PSA-Crypto"
-}
-
 pre_check_environment () {
     # For project detection
-    PROJECT_NAME_FILE='./scripts/project_name.txt'
-    if read -r PROJECT_NAME < "$PROJECT_NAME_FILE"; then :; else
-        echo "$PROJECT_NAME_FILE does not exist... Exiting..." >&2
-        exit 1
+    if [[ -d ../include/mbedtls && -r ../framework/scripts/project_detection.sh ]]; then
+        # we're in tf-psa-crypto as a submodule of mbedtls, grab the framework from mbedtls
+        . ../framework/scripts/project_detection.sh
+    else
+        # we're in TF-PSA-Crypto standalone or in mbedtls, use the local framework
+        . framework/scripts/project_detection.sh
     fi
 
     if in_mbedtls_repo || in_tf_psa_crypto_repo; then :; else

--- a/scripts/all-helpers.sh
+++ b/scripts/all-helpers.sh
@@ -68,10 +68,9 @@ helper_libtestdriver1_adjust_config() {
     fi
 
     # Enable PSA-based config (necessary to use drivers)
-    # The configuration option has been removed for 4.0. While the project and
-    # branch detection shell in shell work is not completed, just ignore the
-    # failure to set MBEDTLS_PSA_CRYPTO_CONFIG.
-    scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG || true
+    if in_mbedtls_repo && in_3_6_branch; then
+        scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
+    fi
 
     # Dynamic secure element support is a deprecated feature and needs to be disabled here.
     # This is done to have the same form of psa_key_attributes_s for libdriver and library.

--- a/scripts/all-helpers.sh
+++ b/scripts/all-helpers.sh
@@ -68,9 +68,10 @@ helper_libtestdriver1_adjust_config() {
     fi
 
     # Enable PSA-based config (necessary to use drivers)
-    if in_mbedtls_repo && in_3_6_branch; then
-        scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG
-    fi
+    # The configuration option has been removed for 4.0. While the project and
+    # branch detection shell in shell work is not completed, just ignore the
+    # failure to set MBEDTLS_PSA_CRYPTO_CONFIG.
+    scripts/config.py set MBEDTLS_PSA_CRYPTO_CONFIG || true
 
     # Dynamic secure element support is a deprecated feature and needs to be disabled here.
     # This is done to have the same form of psa_key_attributes_s for libdriver and library.

--- a/scripts/mbedtls_framework/build_tree.py
+++ b/scripts/mbedtls_framework/build_tree.py
@@ -133,7 +133,7 @@ def guess_tf_psa_crypto_root(root: Optional[str] = None) -> str:
 def is_mbedtls_3_6() -> bool:
     """Whether the working tree is an Mbed TLS 3.6 one or not
 
-    Return false in we are in TF-PSA-Crypto or in Mbed TLS but with a version
+    Return false if we are in TF-PSA-Crypto or in Mbed TLS but with a version
     different from 3.6.x.
     Raise an exception if we are neither in Mbed TLS nor in TF-PSA-Crypto.
     """

--- a/scripts/project_detection.sh
+++ b/scripts/project_detection.sh
@@ -1,0 +1,29 @@
+# project-detection.sh
+#
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+#
+# Purpose
+#
+# This script contains functions for shell scripts to
+# help detect which project (Mbed TLS, TF-PSA-Crypto)
+# or which Mbed TLS branch they are in.
+
+# Project detection
+read_project_name_file () {
+    PROJECT_NAME_FILE='../../scripts/project_name.txt'
+    if read -r PROJECT_NAME < "$PROJECT_NAME_FILE"; then :; else
+        echo "$PROJECT_NAME_FILE does not exist... Exiting..." >&2
+        exit 1
+    fi
+}
+
+in_mbedtls_repo () {
+    read_project_name_file
+    test "$PROJECT_NAME" = "Mbed TLS"
+}
+
+in_tf_psa_crypto_repo () {
+    read_project_name_file
+    test "$PROJECT_NAME" = "TF-PSA-Crypto"
+}

--- a/scripts/project_detection.sh
+++ b/scripts/project_detection.sh
@@ -27,3 +27,36 @@ in_tf_psa_crypto_repo () {
     read_project_name_file
     test "$PROJECT_NAME" = "TF-PSA-Crypto"
 }
+
+#Branch detection
+read_build_info () {
+    BUILD_INFO_FILE='../../include/mbedtls/build_info.h'
+
+    if [ ! -f "$BUILD_INFO_FILE" ]; then
+        echo "File $BUILD_INFO_FILE not found."
+        exit 1
+    fi
+
+    MBEDTLS_VERSION_MAJOR=$(grep "^#define MBEDTLS_VERSION_MAJOR" "$BUILD_INFO_FILE" | awk '{print $3}')
+    MBEDTLS_VERSION_MINOR=$(grep "^#define MBEDTLS_VERSION_MINOR" "$BUILD_INFO_FILE" | awk '{print $3}')
+
+    if [ -z "$MBEDTLS_VERSION_MAJOR" ]; then
+        echo "MBEDTLS_VERSION_MAJOR not found in $BUILD_INFO_FILE."
+        exit 1
+    fi
+
+    if [ -z "$MBEDTLS_VERSION_MINOR" ]; then
+        echo "MBEDTLS_VERSION_MINOR not found in $BUILD_INFO_FILE."
+        exit 1
+    fi
+}
+
+in_3_6_branch () {
+    read_build_info
+    test $MBEDTLS_VERSION_MAJOR = "3" && test $MBEDTLS_VERSION_MINOR = "6"
+}
+
+in_4_x_branch () {
+    read_build_info
+    test $MBEDTLS_VERSION_MAJOR = "4"
+}

--- a/scripts/project_detection.sh
+++ b/scripts/project_detection.sh
@@ -15,12 +15,6 @@ read_project_name_file () {
 
     PROJECT_NAME_FILE="scripts/project_name.txt"
 
-    if echo "$SCRIPT_DIR" | grep -q "/framework/scripts" || echo "$SCRIPT_DIR" | grep -q "/tests/scripts"; then
-        PROJECT_NAME_FILE="../../scripts/project_name.txt"
-    elif echo "$SCRIPT_DIR" | grep -q "/mbedtls/scripts" || echo "$SCRIPT_DIR" | grep -q "/TF-PSA-Crypto/scripts"; then
-        PROJECT_NAME_FILE="project_name.txt"
-    fi
-
     if read -r PROJECT_NAME < "$PROJECT_NAME_FILE"; then :; else
         echo "$PROJECT_NAME_FILE does not exist... Exiting..." >&2
         exit 1
@@ -42,12 +36,6 @@ read_build_info () {
     SCRIPT_DIR=$(pwd)
 
     BUILD_INFO_FILE="include/mbedtls/build_info.h"
-
-    if echo "$SCRIPT_DIR" | grep -q "/framework/scripts" || echo "$SCRIPT_DIR" | grep -q "/tests/scripts"; then
-        BUILD_INFO_FILE="../../include/mbedtls/build_info.h"
-    elif echo "$SCRIPT_DIR" | grep -q "/mbedtls/scripts"; then
-        BUILD_INFO_FILE="../include/mbedtls/build_info.h"
-    fi
 
     if [ ! -f "$BUILD_INFO_FILE" ]; then
         echo "File $BUILD_INFO_FILE not found."

--- a/scripts/project_detection.sh
+++ b/scripts/project_detection.sh
@@ -11,7 +11,16 @@
 
 # Project detection
 read_project_name_file () {
-    PROJECT_NAME_FILE='../../scripts/project_name.txt'
+    SCRIPT_DIR=$(pwd)
+
+    PROJECT_NAME_FILE="scripts/project_name.txt"
+
+    if echo "$SCRIPT_DIR" | grep -q "/framework/scripts" || echo "$SCRIPT_DIR" | grep -q "/tests/scripts"; then
+        PROJECT_NAME_FILE="../../scripts/project_name.txt"
+    elif echo "$SCRIPT_DIR" | grep -q "/mbedtls/scripts" || echo "$SCRIPT_DIR" | grep -q "/TF-PSA-Crypto/scripts"; then
+        PROJECT_NAME_FILE="project_name.txt"
+    fi
+
     if read -r PROJECT_NAME < "$PROJECT_NAME_FILE"; then :; else
         echo "$PROJECT_NAME_FILE does not exist... Exiting..." >&2
         exit 1
@@ -30,7 +39,15 @@ in_tf_psa_crypto_repo () {
 
 #Branch detection
 read_build_info () {
-    BUILD_INFO_FILE='../../include/mbedtls/build_info.h'
+    SCRIPT_DIR=$(pwd)
+
+    BUILD_INFO_FILE="include/mbedtls/build_info.h"
+
+    if echo "$SCRIPT_DIR" | grep -q "/framework/scripts" || echo "$SCRIPT_DIR" | grep -q "/tests/scripts"; then
+        BUILD_INFO_FILE="../../include/mbedtls/build_info.h"
+    elif echo "$SCRIPT_DIR" | grep -q "/mbedtls/scripts"; then
+        BUILD_INFO_FILE="../include/mbedtls/build_info.h"
+    fi
 
     if [ ! -f "$BUILD_INFO_FILE" ]; then
         echo "File $BUILD_INFO_FILE not found."


### PR DESCRIPTION
Resolves #39 

Development: https://github.com/Mbed-TLS/mbedtls/pull/9763
3.6: https://github.com/Mbed-TLS/mbedtls/pull/9764

Gatekeper note (mpg): CI can't pass here as we now depend on the `FRAMEWORK` variables defined by the associated PRs. So, we'll rely on CI status in 9763 and 9764. We also need to merge the 3 PRs at the same time in order to avoid breakage - so we won't do the usual pointer update in 9763 and 9764 after merging this one in order to reduce the window where things are in an inconsistent state. (We can update the pointer to the merge commit as follow-ups to 9763 and 9764.)