### PR TITLE
Add out of source build functions for TF-PSA-Crypto

### DIFF
--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -165,6 +165,7 @@ pre_initialize_variables () {
             PSA_CORE_PATH='tf-psa-crypto/core'
             BUILTIN_SRC_PATH='tf-psa-crypto/drivers/builtin/src'
             CONFIG_TEST_DRIVER_H='tf-psa-crypto/tests/configs/crypto_config_test_driver.h'
+            TF_PSA_CRYPTO_ROOT_DIR="$PWD/tf-psa-crypto"
         fi
         config_files="$CONFIG_H $CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H"
     else
@@ -172,6 +173,7 @@ pre_initialize_variables () {
         PSA_CORE_PATH='core'
         BUILTIN_SRC_PATH='drivers/builtin/src'
         CONFIG_TEST_DRIVER_H='tests/configs/config_test_driver.h'
+        TF_PSA_CRYPTO_ROOT_DIR="$PWD"
 
         config_files="$CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H"
     fi
@@ -937,6 +939,10 @@ run_component () {
         "${dd_cmd[@]}"
     fi
 
+    if in_tf_psa_crypto_repo; then
+        pre_create_tf_psa_crypto_out_of_source_directory
+    fi
+
     # Run the component in a subshell, with error trapping and output
     # redirection set up based on the relevant options.
     if [ $KEEP_GOING -eq 1 ]; then
@@ -971,8 +977,22 @@ run_component () {
     fi
 
     # Restore the build tree to a clean state.
+    if in_tf_psa_crypto_repo; then
+        cleanup_tf_psa_crypto_out_of_source_directory
+    fi
+
     cleanup
     unset current_component
+}
+
+pre_create_tf_psa_crypto_out_of_source_directory () {
+    rm -rf "$OUT_OF_SOURCE_DIR"
+    mkdir "$OUT_OF_SOURCE_DIR"
+    cd "$OUT_OF_SOURCE_DIR"
+}
+cleanup_tf_psa_crypto_out_of_source_directory () {
+    cd "$TF_PSA_CRYPTO_ROOT_DIR"
+    rm -rf "$OUT_OF_SOURCE_DIR"
 }
 
 ################################################################

--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -1002,7 +1002,6 @@ run_component () {
 pre_create_tf_psa_crypto_out_of_source_directory () {
     rm -rf "$OUT_OF_SOURCE_DIR"
     mkdir "$OUT_OF_SOURCE_DIR"
-    cd "$OUT_OF_SOURCE_DIR"
 }
 
 ################################################################

--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -948,11 +948,7 @@ run_component () {
         "${dd_cmd[@]}"
     fi
 
-    # Since building TF-PSA-Crypto is out of source, we cannot identify if we
-    # are in TF-PSA-Crypto repository. We set running_tf_psa_crypto_test.
-    running_tf_psa_crypto_test=0
     if in_tf_psa_crypto_repo; then
-        running_tf_psa_crypto_test=1
         pre_create_tf_psa_crypto_out_of_source_directory
     fi
 
@@ -987,11 +983,6 @@ run_component () {
         if [ $component_status -ne 0 ]; then
             failure_count=$((failure_count + 1))
         fi
-    fi
-
-    # Reset working directory to TF_PSA_Crypto as it is build out of source..
-    if [ $running_tf_psa_crypto_test -eq 1 ]; then
-        cd "$TF_PSA_CRYPTO_ROOT_DIR"
     fi
 
     # Restore the build tree to a clean state.

--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -167,6 +167,7 @@ pre_initialize_variables () {
             CONFIG_TEST_DRIVER_H='tf-psa-crypto/tests/configs/crypto_config_test_driver.h'
             MBEDTLS_ROOT_DIR="$PWD"
             TF_PSA_CRYPTO_ROOT_DIR="$PWD/tf-psa-crypto"
+            MBEDTLS_FRAMEWORK_ROOT_DIR="$PWD/framework"
         fi
         config_files="$CONFIG_H $CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H"
     else
@@ -176,6 +177,7 @@ pre_initialize_variables () {
         CONFIG_TEST_DRIVER_H='tests/configs/config_test_driver.h'
         TF_PSA_CRYPTO_ROOT_DIR="$PWD"
         MBEDTLS_ROOT_DIR=""
+        MBEDTLS_FRAMEWORK_ROOT_DIR="$PWD/framework"
 
         config_files="$CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H"
     fi

--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -220,7 +220,7 @@ pre_initialize_variables () {
     : ${OPENSSL_NEXT:="$OPENSSL"}
     : ${GNUTLS_CLI:="gnutls-cli"}
     : ${GNUTLS_SERV:="gnutls-serv"}
-    : ${OUT_OF_SOURCE_DIR:=./mbedtls_out_of_source_build}
+    : ${OUT_OF_SOURCE_DIR:=$PWD/out_of_source_build}
     : ${ARMC6_BIN_DIR:=/usr/bin}
     : ${ARM_NONE_EABI_GCC_PREFIX:=arm-none-eabi-}
     : ${ARM_LINUX_GNUEABI_GCC_PREFIX:=arm-linux-gnueabi-}

--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -167,7 +167,6 @@ pre_initialize_variables () {
             CONFIG_TEST_DRIVER_H='tf-psa-crypto/tests/configs/crypto_config_test_driver.h'
             MBEDTLS_ROOT_DIR="$PWD"
             TF_PSA_CRYPTO_ROOT_DIR="$PWD/tf-psa-crypto"
-            MBEDTLS_FRAMEWORK_ROOT_DIR="$PWD/framework"
         fi
         config_files="$CONFIG_H $CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H"
     else
@@ -177,7 +176,6 @@ pre_initialize_variables () {
         CONFIG_TEST_DRIVER_H='tests/configs/config_test_driver.h'
         TF_PSA_CRYPTO_ROOT_DIR="$PWD"
         MBEDTLS_ROOT_DIR=""
-        MBEDTLS_FRAMEWORK_ROOT_DIR="$PWD/framework"
 
         config_files="$CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H"
     fi

--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -404,6 +404,11 @@ cleanup()
     rm -f programs/test/cmake_package_install/Makefile
     rm -f programs/test/cmake_package_install/cmake_package_install
 
+    # Remove out of source directory
+    if in_tf_psa_crypto_repo; then
+        rm -rf "$OUT_OF_SOURCE_DIR"
+    fi
+
     # Restore files that may have been clobbered by the job
     restore_backed_up_files
 }
@@ -941,7 +946,11 @@ run_component () {
         "${dd_cmd[@]}"
     fi
 
+    # Since building TF-PSA-Crypto is out of source, we cannot identify if we
+    # are in TF-PSA-Crypto repository. We set running_tf_psa_crypto_test.
+    running_tf_psa_crypto_test=0
     if in_tf_psa_crypto_repo; then
+        running_tf_psa_crypto_test=1
         pre_create_tf_psa_crypto_out_of_source_directory
     fi
 
@@ -978,11 +987,12 @@ run_component () {
         fi
     fi
 
-    # Restore the build tree to a clean state.
-    if in_tf_psa_crypto_repo; then
-        cleanup_tf_psa_crypto_out_of_source_directory
+    # Reset working directory to TF_PSA_Crypto as it is build out of source..
+    if [ $running_tf_psa_crypto_test -eq 1 ]; then
+        cd "$TF_PSA_CRYPTO_ROOT_DIR"
     fi
 
+    # Restore the build tree to a clean state.
     cleanup
     unset current_component
 }
@@ -991,10 +1001,6 @@ pre_create_tf_psa_crypto_out_of_source_directory () {
     rm -rf "$OUT_OF_SOURCE_DIR"
     mkdir "$OUT_OF_SOURCE_DIR"
     cd "$OUT_OF_SOURCE_DIR"
-}
-cleanup_tf_psa_crypto_out_of_source_directory () {
-    cd "$TF_PSA_CRYPTO_ROOT_DIR"
-    rm -rf "$OUT_OF_SOURCE_DIR"
 }
 
 ################################################################

--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -165,6 +165,7 @@ pre_initialize_variables () {
             PSA_CORE_PATH='tf-psa-crypto/core'
             BUILTIN_SRC_PATH='tf-psa-crypto/drivers/builtin/src'
             CONFIG_TEST_DRIVER_H='tf-psa-crypto/tests/configs/crypto_config_test_driver.h'
+            MBEDTLS_ROOT_DIR="$PWD"
             TF_PSA_CRYPTO_ROOT_DIR="$PWD/tf-psa-crypto"
         fi
         config_files="$CONFIG_H $CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H"
@@ -174,6 +175,7 @@ pre_initialize_variables () {
         BUILTIN_SRC_PATH='drivers/builtin/src'
         CONFIG_TEST_DRIVER_H='tests/configs/config_test_driver.h'
         TF_PSA_CRYPTO_ROOT_DIR="$PWD"
+        MBEDTLS_ROOT_DIR=""
 
         config_files="$CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H"
     fi


### PR DESCRIPTION
This commit adds helper functions to build TF-PSA-Crypto out of source using CMake.

This commit is used for: https://github.com/Mbed-TLS/mbedtls/pull/9767