### PR TITLE
Port `psa_exercise_key` changes added mid-framework-move

### DIFF
--- a/tests/include/test/psa_exercise_key.h
+++ b/tests/include/test/psa_exercise_key.h
@@ -138,7 +138,7 @@ int mbedtls_test_psa_setup_key_derivation_wrap(
     size_t capacity, int key_destroyable);
 
 /** Perform a key agreement using the given key pair against its public key
- * using psa_raw_key_agreement().
+ * using psa_raw_key_agreement() and psa_key_agreement().
  *
  * The result is discarded. The purpose of this function is to smoke-test a key.
  *

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -693,7 +693,16 @@ psa_status_t mbedtls_test_psa_raw_key_agreement_with_self(
     size_t public_key_length;
     uint8_t output[1024];
     size_t output_length;
+
+    uint8_t *exported = NULL;
+    size_t exported_size = 0;
+    size_t exported_length = 0;
+
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+    psa_key_attributes_t export_attributes = PSA_KEY_ATTRIBUTES_INIT;
+
+    mbedtls_svc_key_id_t shared_secret_id = MBEDTLS_SVC_KEY_ID_INIT;
+    psa_key_attributes_t shared_secret_attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     psa_status_t status = psa_get_key_attributes(key, &attributes);
     if (key_destroyable && status == PSA_ERROR_INVALID_HANDLE) {
@@ -734,14 +743,53 @@ psa_status_t mbedtls_test_psa_raw_key_agreement_with_self(
                     PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE);
     }
 
+    psa_set_key_type(&shared_secret_attributes, PSA_KEY_TYPE_DERIVE);
+    psa_set_key_usage_flags(&shared_secret_attributes, PSA_KEY_USAGE_DERIVE | PSA_KEY_USAGE_EXPORT);
+
+    status = psa_key_agreement(key, public_key, public_key_length, alg,
+                               &shared_secret_attributes, &shared_secret_id);
+
+    if (key_destroyable && status == PSA_ERROR_INVALID_HANDLE) {
+        /* The key has been destroyed. */
+        status = PSA_SUCCESS;
+        goto exit;
+    } else if (status == PSA_SUCCESS) {
+
+        status = psa_get_key_attributes(shared_secret_id, &export_attributes);
+        if (key_destroyable && status == PSA_ERROR_INVALID_HANDLE) {
+            /* The key has been destroyed. */
+            status = PSA_SUCCESS;
+            goto exit;
+        }
+
+        exported_size = PSA_EXPORT_KEY_OUTPUT_SIZE(psa_get_key_type(&export_attributes),
+                                                   psa_get_key_bits(&export_attributes));
+        TEST_CALLOC(exported, exported_size);
+
+        status = psa_export_key(shared_secret_id, exported, exported_size, &exported_length);
+
+        if (key_destroyable && status == PSA_ERROR_INVALID_HANDLE) {
+            /* The key has been destroyed. */
+            status = PSA_SUCCESS;
+        }
+
+        PSA_ASSERT(status);
+    }
+
 exit:
     /*
      * Key attributes may have been returned by psa_get_key_attributes()
      * thus reset them as required.
      */
     psa_reset_key_attributes(&attributes);
+    psa_reset_key_attributes(&export_attributes);
+
+    /* Make sure to reset and free derived key attributes and slot. */
+    psa_reset_key_attributes(&shared_secret_attributes);
+    psa_destroy_key(shared_secret_id);
 
     mbedtls_free(public_key);
+    mbedtls_free(exported);
     return status;
 }
 

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -694,15 +694,18 @@ psa_status_t mbedtls_test_psa_raw_key_agreement_with_self(
     uint8_t output[1024];
     size_t output_length;
 
+#if MBEDTLS_VERSION_MAJOR >= 4
     uint8_t *exported = NULL;
     size_t exported_size = 0;
     size_t exported_length = 0;
 
-    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_attributes_t export_attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     mbedtls_svc_key_id_t shared_secret_id = MBEDTLS_SVC_KEY_ID_INIT;
     psa_key_attributes_t shared_secret_attributes = PSA_KEY_ATTRIBUTES_INIT;
+#endif /* MBEDTLS_VERSION_MAJOR >= 4 */
+
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
 
     psa_status_t status = psa_get_key_attributes(key, &attributes);
     if (key_destroyable && status == PSA_ERROR_INVALID_HANDLE) {
@@ -743,6 +746,7 @@ psa_status_t mbedtls_test_psa_raw_key_agreement_with_self(
                     PSA_RAW_KEY_AGREEMENT_OUTPUT_MAX_SIZE);
     }
 
+#if MBEDTLS_VERSION_MAJOR >= 4
     psa_set_key_type(&shared_secret_attributes, PSA_KEY_TYPE_DERIVE);
     psa_set_key_usage_flags(&shared_secret_attributes, PSA_KEY_USAGE_DERIVE | PSA_KEY_USAGE_EXPORT);
 
@@ -775,6 +779,7 @@ psa_status_t mbedtls_test_psa_raw_key_agreement_with_self(
 
         PSA_ASSERT(status);
     }
+#endif /* MBEDTLS_VERSION_MAJOR >= 4 */
 
 exit:
     /*
@@ -782,14 +787,18 @@ exit:
      * thus reset them as required.
      */
     psa_reset_key_attributes(&attributes);
+
+#if MBEDTLS_VERSION_MAJOR >= 4
     psa_reset_key_attributes(&export_attributes);
 
     /* Make sure to reset and free derived key attributes and slot. */
     psa_reset_key_attributes(&shared_secret_attributes);
     psa_destroy_key(shared_secret_id);
 
-    mbedtls_free(public_key);
     mbedtls_free(exported);
+#endif /* MBEDTLS_VERSION_MAJOR >= 4 */
+
+    mbedtls_free(public_key);
     return status;
 }
 


### PR DESCRIPTION
These changes to `psa_exercise_key` were added while the files were being moved to the framework. Port them to the framework now.