### PR TITLE
Switch generate_psa_test.py to automatic dependencies for positive test cases

### DIFF
--- a/scripts/generate_psa_tests.py
+++ b/scripts/generate_psa_tests.py
@@ -33,7 +33,6 @@ def test_case_for_key_type_not_supported(
     """Return one test case exercising a key creation method
     for an unsupported key type or size.
     """
-    psa_information.hack_dependencies_not_implemented(dependencies)
     tc = psa_test_case.TestCase()
     short_key_type = crypto_knowledge.short_expression(key_type)
     adverb = 'not' if dependencies else 'never'
@@ -44,6 +43,7 @@ def test_case_for_key_type_not_supported(
     tc.set_function(verb + '_not_supported')
     tc.set_arguments([key_type] + list(args))
     tc.set_dependencies(dependencies)
+    tc.skip_if_any_not_implemented(dependencies)
     return tc
 
 class KeyTypeNotSupported:
@@ -148,7 +148,6 @@ def test_case_for_key_generation(
 ) -> test_case.TestCase:
     """Return one test case exercising a key generation.
     """
-    psa_information.hack_dependencies_not_implemented(dependencies)
     tc = psa_test_case.TestCase()
     short_key_type = crypto_knowledge.short_expression(key_type)
     tc.set_description('PSA {} {}-bit'
@@ -156,7 +155,7 @@ def test_case_for_key_generation(
     tc.set_function('generate_key')
     tc.set_arguments([key_type] + list(args) + [result])
     tc.set_dependencies(dependencies)
-
+    tc.skip_if_any_not_implemented(dependencies)
     return tc
 
 class KeyGenerate:

--- a/scripts/generate_psa_tests.py
+++ b/scripts/generate_psa_tests.py
@@ -42,6 +42,7 @@ def test_case_for_key_type_not_supported(
                        .format(verb, short_key_type, bits, adverb))
     tc.set_function(verb + '_not_supported')
     tc.set_key_bits(bits)
+    tc.set_key_pair_usage(verb.upper())
     tc.set_arguments([key_type] + list(args))
     tc.set_dependencies(dependencies)
     tc.skip_if_any_not_implemented(dependencies)
@@ -155,6 +156,7 @@ def test_case_for_key_generation(
                        .format(short_key_type, bits))
     tc.set_function('generate_key')
     tc.set_key_bits(bits)
+    tc.set_key_pair_usage('GENERATE')
     tc.set_arguments([key_type] + list(args) + [result])
     tc.set_dependencies(dependencies)
     tc.skip_if_any_not_implemented(dependencies)
@@ -503,6 +505,7 @@ class StorageFormat:
         dependencies = psa_information.fix_key_pair_dependencies(dependencies, 'BASIC')
         tc.set_function('key_storage_' + verb)
         tc.set_key_bits(key.bits)
+        tc.set_key_pair_usage('BASIC')
         if self.forward:
             extra_arguments = []
         else:

--- a/scripts/generate_psa_tests.py
+++ b/scripts/generate_psa_tests.py
@@ -41,6 +41,7 @@ def test_case_for_key_type_not_supported(
     tc.set_description('PSA {} {} {}-bit {} supported'
                        .format(verb, short_key_type, bits, adverb))
     tc.set_function(verb + '_not_supported')
+    tc.set_key_bits(bits)
     tc.set_arguments([key_type] + list(args))
     tc.set_dependencies(dependencies)
     tc.skip_if_any_not_implemented(dependencies)
@@ -153,6 +154,7 @@ def test_case_for_key_generation(
     tc.set_description('PSA {} {}-bit'
                        .format(short_key_type, bits))
     tc.set_function('generate_key')
+    tc.set_key_bits(bits)
     tc.set_arguments([key_type] + list(args) + [result])
     tc.set_dependencies(dependencies)
     tc.skip_if_any_not_implemented(dependencies)
@@ -279,7 +281,9 @@ class OpFail:
         tc.set_function(category.name.lower() + '_fail')
         arguments = [] # type: List[str]
         if kt:
-            key_material = kt.key_material(kt.sizes_to_test()[0])
+            bits = kt.sizes_to_test()[0]
+            tc.set_key_bits(bits)
+            key_material = kt.key_material(bits)
             arguments += [key_type, test_case.hex_string(key_material)]
         arguments.append(alg.expression)
         if category.is_asymmetric():
@@ -498,6 +502,7 @@ class StorageFormat:
         dependencies += psa_information.generate_deps_from_description(key.description)
         dependencies = psa_information.fix_key_pair_dependencies(dependencies, 'BASIC')
         tc.set_function('key_storage_' + verb)
+        tc.set_key_bits(key.bits)
         if self.forward:
             extra_arguments = []
         else:

--- a/scripts/mbedtls_framework/crypto_data_tests.py
+++ b/scripts/mbedtls_framework/crypto_data_tests.py
@@ -12,6 +12,7 @@ from typing import Callable, Dict, Iterator, List, Optional #pylint: disable=unu
 
 from . import crypto_knowledge
 from . import psa_information
+from . import psa_test_case
 from . import test_case
 
 
@@ -69,7 +70,7 @@ class HashPSALowLevel:
                       function: str, note: str,
                       arguments: List[str]) -> test_case.TestCase:
         """Construct one test case involving a hash."""
-        tc = test_case.TestCase()
+        tc = psa_test_case.TestCase()
         tc.set_description('{}{} {}'
                            .format(function,
                                    ' ' + note if note else '',

--- a/scripts/mbedtls_framework/crypto_data_tests.py
+++ b/scripts/mbedtls_framework/crypto_data_tests.py
@@ -21,10 +21,8 @@ def psa_low_level_dependencies(*expressions: str) -> List[str]:
 
     This function generates MBEDTLS_PSA_BUILTIN_xxx symbols.
     """
-    high_level = psa_information.automatic_dependencies(*expressions)
-    for dep in high_level:
-        assert dep.startswith('PSA_WANT_')
-    return ['MBEDTLS_PSA_BUILTIN_' + dep[9:] for dep in high_level]
+    return psa_information.automatic_dependencies(*expressions,
+                                                  prefix='MBEDTLS_PSA_BUILTIN_')
 
 
 class HashPSALowLevel:

--- a/scripts/mbedtls_framework/crypto_data_tests.py
+++ b/scripts/mbedtls_framework/crypto_data_tests.py
@@ -74,10 +74,10 @@ class HashPSALowLevel:
                            .format(function,
                                    ' ' + note if note else '',
                                    alg.short_expression()))
-        tc.set_dependencies(psa_low_level_dependencies(alg.expression))
         tc.set_function(function)
         tc.set_arguments([alg.expression] +
                          ['"{}"'.format(arg) for arg in arguments])
+        tc.set_dependencies(psa_low_level_dependencies(alg.expression))
         return tc
 
     def test_cases_for_hash(self,

--- a/scripts/mbedtls_framework/crypto_data_tests.py
+++ b/scripts/mbedtls_framework/crypto_data_tests.py
@@ -16,15 +16,6 @@ from . import psa_test_case
 from . import test_case
 
 
-def psa_low_level_dependencies(*expressions: str) -> List[str]:
-    """Infer dependencies of a PSA low-level test case by looking for PSA_xxx symbols.
-
-    This function generates MBEDTLS_PSA_BUILTIN_xxx symbols.
-    """
-    return psa_information.automatic_dependencies(*expressions,
-                                                  prefix='MBEDTLS_PSA_BUILTIN_')
-
-
 class HashPSALowLevel:
     """Generate test cases for the PSA low-level hash interface."""
 
@@ -68,7 +59,7 @@ class HashPSALowLevel:
                       function: str, note: str,
                       arguments: List[str]) -> test_case.TestCase:
         """Construct one test case involving a hash."""
-        tc = psa_test_case.TestCase()
+        tc = psa_test_case.TestCase(dependency_prefix='MBEDTLS_PSA_BUILTIN_')
         tc.set_description('{}{} {}'
                            .format(function,
                                    ' ' + note if note else '',
@@ -76,7 +67,6 @@ class HashPSALowLevel:
         tc.set_function(function)
         tc.set_arguments([alg.expression] +
                          ['"{}"'.format(arg) for arg in arguments])
-        tc.set_dependencies(psa_low_level_dependencies(alg.expression))
         return tc
 
     def test_cases_for_hash(self,

--- a/scripts/mbedtls_framework/psa_information.py
+++ b/scripts/mbedtls_framework/psa_information.py
@@ -8,7 +8,7 @@
 import os
 import re
 from collections import OrderedDict
-from typing import FrozenSet, List, Optional
+from typing import List, Optional
 
 from . import macro_collector
 
@@ -122,35 +122,6 @@ def generate_deps_from_description(
             dep_list += deps
 
     return dep_list
-
-# A temporary hack: at the time of writing, not all dependency symbols
-# are implemented yet. Skip test cases for which the dependency symbols are
-# not available. Once all dependency symbols are available, this hack must
-# be removed so that a bug in the dependency symbols properly leads to a test
-# failure.
-def read_implemented_dependencies(filename: str) -> FrozenSet[str]:
-    return frozenset(symbol
-                     for line in open(filename)
-                     for symbol in re.findall(r'\bPSA_WANT_\w+\b', line))
-_implemented_dependencies = None #type: Optional[FrozenSet[str]] #pylint: disable=invalid-name
-
-def find_dependencies_not_implemented(dependencies: List[str]) -> List[str]:
-    """List the dependencies that are not implemented."""
-    global _implemented_dependencies #pylint: disable=global-statement,invalid-name
-    if _implemented_dependencies is None:
-        # Temporary, while Mbed TLS does not just rely on the TF-PSA-Crypto
-        # build system to build its crypto library. When it does, the first
-        # case can just be removed.
-        if os.path.isdir('tf-psa-crypto'):
-            _implemented_dependencies = \
-                read_implemented_dependencies('tf-psa-crypto/include/psa/crypto_config.h')
-        else:
-            _implemented_dependencies = \
-                read_implemented_dependencies('include/psa/crypto_config.h')
-    return [dep
-            for dep in dependencies
-            if (dep.lstrip('!') not in _implemented_dependencies and
-                dep.lstrip('!').startswith('PSA_WANT'))]
 
 def tweak_key_pair_dependency(dep: str, usage: str):
     """

--- a/scripts/mbedtls_framework/psa_information.py
+++ b/scripts/mbedtls_framework/psa_information.py
@@ -23,8 +23,13 @@ class Information:
     def remove_unwanted_macros(
             constructors: macro_collector.PSAMacroEnumerator
     ) -> None:
-        # Mbed TLS does not support finite-field DSA.
+        """Remove constructors that should be exckuded from systematic testing."""
+        # Mbed TLS does not support finite-field DSA, but 3.6 defines DSA
+        # identifiers for historical reasons.
         # Don't attempt to generate any related test case.
+        # The corresponding test cases would be commented out anyway,
+        # but for DSA, we don't have enough support in the test scripts
+        # to generate these test cases.
         constructors.key_types.discard('PSA_KEY_TYPE_DSA_KEY_PAIR')
         constructors.key_types.discard('PSA_KEY_TYPE_DSA_PUBLIC_KEY')
 

--- a/scripts/mbedtls_framework/psa_test_case.py
+++ b/scripts/mbedtls_framework/psa_test_case.py
@@ -89,4 +89,5 @@ class TestCase(test_case.TestCase):
         """Skip the test case if any of the given dependencies is not implemented."""
         not_implemented = find_dependencies_not_implemented(dependencies)
         if not_implemented:
-            self.add_dependencies(['DEPENDENCY_NOT_IMPLEMENTED_YET'])
+            self.skip_because('not implemented: ' +
+                              ' '.join(not_implemented))

--- a/scripts/mbedtls_framework/psa_test_case.py
+++ b/scripts/mbedtls_framework/psa_test_case.py
@@ -113,12 +113,18 @@ class TestCase(test_case.TestCase):
     def set_arguments(self, arguments: List[str]) -> None:
         """Set test case arguments and automatically infer dependencies."""
         super().set_arguments(arguments)
-        self.automatic_dependencies.update(self.infer_dependencies(arguments))
+        dependencies = self.infer_dependencies(arguments)
+        self.skip_if_any_not_implemented(dependencies)
+        self.automatic_dependencies.update(dependencies)
 
     def set_dependencies(self, dependencies: List[str]) -> None:
-        """Override any previously added automatic or manual dependencies."""
+        """Override any previously added automatic or manual dependencies.
+
+        Also override any previous instruction to skip the test case.
+        """
         self.manual_dependencies = dependencies
         self.automatic_dependencies.clear()
+        self.skip_reasons = []
 
     def add_dependencies(self, dependencies: List[str]) -> None:
         """Add manual dependencies."""
@@ -135,6 +141,5 @@ class TestCase(test_case.TestCase):
     def skip_if_any_not_implemented(self, dependencies: List[str]) -> None:
         """Skip the test case if any of the given dependencies is not implemented."""
         not_implemented = find_dependencies_not_implemented(dependencies)
-        if not_implemented:
-            self.skip_because('not implemented: ' +
-                              ' '.join(not_implemented))
+        for dep in not_implemented:
+            self.skip_because('not implemented: ' + dep)

--- a/scripts/mbedtls_framework/psa_test_case.py
+++ b/scripts/mbedtls_framework/psa_test_case.py
@@ -83,7 +83,12 @@ class TestCase(test_case.TestCase):
         self.manual_dependencies += dependencies
 
     def get_dependencies(self) -> List[str]:
-        return sorted(self.automatic_dependencies) + self.manual_dependencies
+        # Make the output independent of the order in which the dependencies
+        # are calculated by the script. Also avoid duplicates. This makes
+        # the output robust with respect to refactoring of the scripts.
+        dependencies = set(self.manual_dependencies)
+        dependencies.update(self.automatic_dependencies)
+        return sorted(dependencies)
 
     def skip_if_any_not_implemented(self, dependencies: List[str]) -> None:
         """Skip the test case if any of the given dependencies is not implemented."""

--- a/scripts/mbedtls_framework/psa_test_case.py
+++ b/scripts/mbedtls_framework/psa_test_case.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 #
 
+from typing import List, Set
+
 from . import test_case
 
 
@@ -18,3 +20,28 @@ class TestCase(test_case.TestCase):
 
     def __init__(self) -> None:
         super().__init__()
+        del self.dependencies
+        self.manual_dependencies = [] #type: List[str]
+        self.automatic_dependencies = set() #type: Set[str]
+
+    @staticmethod
+    def infer_dependencies(_arguments: List[str]) -> List[str]:
+        """Infer dependencies based on the test case arguments."""
+        return [] # not implemented yet
+
+    def set_arguments(self, arguments: List[str]) -> None:
+        """Set test case arguments and automatically infer dependencies."""
+        super().set_arguments(arguments)
+        self.automatic_dependencies.update(self.infer_dependencies(arguments))
+
+    def set_dependencies(self, dependencies: List[str]) -> None:
+        """Override any previously added automatic or manual dependencies."""
+        self.manual_dependencies = dependencies
+        self.automatic_dependencies.clear()
+
+    def add_dependencies(self, dependencies: List[str]) -> None:
+        """Add manual dependencies."""
+        self.manual_dependencies += dependencies
+
+    def get_dependencies(self) -> List[str]:
+        return sorted(self.automatic_dependencies) + self.manual_dependencies

--- a/scripts/mbedtls_framework/psa_test_case.py
+++ b/scripts/mbedtls_framework/psa_test_case.py
@@ -7,6 +7,7 @@
 
 from typing import List, Set
 
+from . import psa_information
 from . import test_case
 
 
@@ -45,3 +46,9 @@ class TestCase(test_case.TestCase):
 
     def get_dependencies(self) -> List[str]:
         return sorted(self.automatic_dependencies) + self.manual_dependencies
+
+    def skip_if_any_not_implemented(self, dependencies: List[str]) -> None:
+        """Skip the test case if any of the given dependencies is not implemented."""
+        not_implemented = psa_information.find_dependencies_not_implemented(dependencies)
+        if not_implemented:
+            self.add_dependencies(['DEPENDENCY_NOT_IMPLEMENTED_YET'])

--- a/scripts/mbedtls_framework/psa_test_case.py
+++ b/scripts/mbedtls_framework/psa_test_case.py
@@ -103,6 +103,11 @@ class TestCase(test_case.TestCase):
         if self.key_pair_usage is not None:
             dependencies = psa_information.fix_key_pair_dependencies(dependencies,
                                                                      self.key_pair_usage)
+        if 'PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_GENERATE' in dependencies and \
+           self.key_bits is not None:
+            size_dependency = ('PSA_VENDOR_RSA_GENERATE_MIN_KEY_BITS <= ' +
+                               str(self.key_bits))
+            dependencies.append(size_dependency)
         return dependencies
 
     def set_arguments(self, arguments: List[str]) -> None:

--- a/scripts/mbedtls_framework/psa_test_case.py
+++ b/scripts/mbedtls_framework/psa_test_case.py
@@ -9,6 +9,7 @@ import os
 import re
 from typing import FrozenSet, List, Optional, Set
 
+from . import psa_information
 from . import test_case
 
 
@@ -57,16 +58,24 @@ class TestCase(test_case.TestCase):
     involved in a given test case.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, dependency_prefix: Optional[str] = None) -> None:
+        """Construct a test case for a PSA Crypto API call.
+
+        `dependency_prefix`: prefix to use in dependencies. Defaults to
+                             ``'PSA_WANT_'``. Use ``'MBEDTLS_PSA_BUILTIN_'``
+                             when specifically testing builtin implementations.
+        """
         super().__init__()
         del self.dependencies
         self.manual_dependencies = [] #type: List[str]
         self.automatic_dependencies = set() #type: Set[str]
+        self.dependency_prefix = dependency_prefix #type: Optional[str]
 
-    @staticmethod
-    def infer_dependencies(_arguments: List[str]) -> List[str]:
+    def infer_dependencies(self, arguments: List[str]) -> List[str]:
         """Infer dependencies based on the test case arguments."""
-        return [] # not implemented yet
+        dependencies = psa_information.automatic_dependencies(*arguments,
+                                                              prefix=self.dependency_prefix)
+        return dependencies
 
     def set_arguments(self, arguments: List[str]) -> None:
         """Set test case arguments and automatically infer dependencies."""

--- a/scripts/mbedtls_framework/psa_test_case.py
+++ b/scripts/mbedtls_framework/psa_test_case.py
@@ -71,6 +71,7 @@ class TestCase(test_case.TestCase):
         self.automatic_dependencies = set() #type: Set[str]
         self.dependency_prefix = dependency_prefix #type: Optional[str]
         self.key_bits = None #type: Optional[int]
+        self.key_pair_usage = None #type: Optional[str]
 
     def set_key_bits(self, key_bits: Optional[int]) -> None:
         """Use the given key size for automatic dependency generation.
@@ -82,6 +83,16 @@ class TestCase(test_case.TestCase):
         """
         self.key_bits = key_bits
 
+    def set_key_pair_usage(self, key_pair_usage: Optional[str]) -> None:
+        """Use the given suffix for key pair dependencies.
+
+        Call this function before set_arguments() if relevant.
+
+        This is only relevant for key pair types. For other key types,
+        this information is ignored.
+        """
+        self.key_pair_usage = key_pair_usage
+
     def infer_dependencies(self, arguments: List[str]) -> List[str]:
         """Infer dependencies based on the test case arguments."""
         dependencies = psa_information.automatic_dependencies(*arguments,
@@ -89,6 +100,9 @@ class TestCase(test_case.TestCase):
         if self.key_bits is not None:
             dependencies = psa_information.finish_family_dependencies(dependencies,
                                                                       self.key_bits)
+        if self.key_pair_usage is not None:
+            dependencies = psa_information.fix_key_pair_dependencies(dependencies,
+                                                                     self.key_pair_usage)
         return dependencies
 
     def set_arguments(self, arguments: List[str]) -> None:

--- a/scripts/mbedtls_framework/psa_test_case.py
+++ b/scripts/mbedtls_framework/psa_test_case.py
@@ -70,11 +70,25 @@ class TestCase(test_case.TestCase):
         self.manual_dependencies = [] #type: List[str]
         self.automatic_dependencies = set() #type: Set[str]
         self.dependency_prefix = dependency_prefix #type: Optional[str]
+        self.key_bits = None #type: Optional[int]
+
+    def set_key_bits(self, key_bits: Optional[int]) -> None:
+        """Use the given key size for automatic dependency generation.
+
+        Call this function before set_arguments() if relevant.
+
+        This is only relevant for ECC and DH keys. For other key types,
+        this information is ignored.
+        """
+        self.key_bits = key_bits
 
     def infer_dependencies(self, arguments: List[str]) -> List[str]:
         """Infer dependencies based on the test case arguments."""
         dependencies = psa_information.automatic_dependencies(*arguments,
                                                               prefix=self.dependency_prefix)
+        if self.key_bits is not None:
+            dependencies = psa_information.finish_family_dependencies(dependencies,
+                                                                      self.key_bits)
         return dependencies
 
     def set_arguments(self, arguments: List[str]) -> None:

--- a/scripts/mbedtls_framework/psa_test_case.py
+++ b/scripts/mbedtls_framework/psa_test_case.py
@@ -1,0 +1,20 @@
+"""Generate test cases for PSA API calls, with automatic dependencies.
+"""
+
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+#
+
+from . import test_case
+
+
+class TestCase(test_case.TestCase):
+    """A PSA test case with automatically inferred dependencies.
+
+    For mechanisms like ECC curves where the support status includes
+    the key bit-size, this class assumes that only one bit-size is
+    involved in a given test case.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()

--- a/scripts/mbedtls_framework/test_case.py
+++ b/scripts/mbedtls_framework/test_case.py
@@ -65,6 +65,9 @@ class TestCase:
     def set_description(self, description: str) -> None:
         self.description = description
 
+    def get_dependencies(self) -> List[str]:
+        return self.dependencies
+
     def set_dependencies(self, dependencies: List[str]) -> None:
         self.dependencies = dependencies
 
@@ -117,9 +120,10 @@ class TestCase:
             for reason in self.skip_reasons:
                 out.write('## # skipped because: ' + reason + '\n')
         out.write(prefix + self.description + '\n')
-        if self.dependencies:
+        dependencies = self.get_dependencies()
+        if dependencies:
             out.write(prefix + 'depends_on:' +
-                      ':'.join(self.dependencies) + '\n')
+                      ':'.join(dependencies) + '\n')
         out.write(prefix + self.function + ':' +
                   ':'.join(self.arguments) + '\n')
 

--- a/scripts/mbedtls_framework/test_case.py
+++ b/scripts/mbedtls_framework/test_case.py
@@ -57,6 +57,7 @@ class TestCase:
         self.dependencies = [] #type: List[str]
         self.function = None #type: Optional[str]
         self.arguments = [] #type: List[str]
+        self.skip_reasons = [] #type: List[str]
 
     def add_comment(self, *lines: str) -> None:
         self.comments += lines
@@ -72,6 +73,23 @@ class TestCase:
 
     def set_arguments(self, arguments: List[str]) -> None:
         self.arguments = arguments
+
+    def skip_because(self, reason: str) -> None:
+        """Skip this test case.
+
+        It will be included in the output, but commented out.
+
+        This is intended for test cases that are obtained from a
+        systematic enumeration, but that have dependencies that cannot
+        be fulfilled. Since we don't want to have test cases that are
+        never executed, we arrange not to have actual test cases. But
+        we do include comments to make it easier to understand the output
+        of test case generation.
+
+        reason must be a non-empty string explaining to humans why this
+        test case is skipped.
+        """
+        self.skip_reasons.append(reason)
 
     def check_completeness(self) -> None:
         if self.description is None:
@@ -93,10 +111,17 @@ class TestCase:
         out.write('\n')
         for line in self.comments:
             out.write('# ' + line + '\n')
-        out.write(self.description + '\n')
+        prefix = ''
+        if self.skip_reasons:
+            prefix = '## '
+            for reason in self.skip_reasons:
+                out.write('## # skipped because: ' + reason + '\n')
+        out.write(prefix + self.description + '\n')
         if self.dependencies:
-            out.write('depends_on:' + ':'.join(self.dependencies) + '\n')
-        out.write(self.function + ':' + ':'.join(self.arguments) + '\n')
+            out.write(prefix + 'depends_on:' +
+                      ':'.join(self.dependencies) + '\n')
+        out.write(prefix + self.function + ':' +
+                  ':'.join(self.arguments) + '\n')
 
 def write_data_file(filename: str,
                     test_cases: Iterable[TestCase],


### PR DESCRIPTION
This is mostly refactoring around `generate_psa_tests.py` and supporting Python libraries. Create a class for test case generation that can automatically determine test case dependencies. Use this for `generate_psa_tests.py` for positive test cases.

Practical effect:

* Never-executed test cases are now easier to work with, because they're commented out and have the reason in a comment.
* Fix some test cases that were not properly detected as never-executed.

This is a step on the forward port of https://github.com/Mbed-TLS/mbedtls/pull/9025. Here, I handle the positive test cases of `generate_psa_tests.py`, which brings me to a natural cutoff point.

Follow-up: handling the negative test cases (`KeyTypeNotSupported`, `OpFail`).

## Review recommendations

The commits are broken down in a way to make their impact on the generated files easy to understand. Only three commits change the output, the others are pure refactoring:

* 119b3b9740b1a64d0ee8ca302a5dcd72b6d36d3d
* e3f9189103de9f14702fa8f8581457d179d8f0e4
* e1f38eb599fffb6b3ac14b087a5f38306d89279f

To validate my claims about the impact on the generated files, I use `mbedtls-trace-files.py` from https://github.com/Mbed-TLS/mbedtls-docs/pull/23 combined with the `diff-pairs` script attached here.
[diff-pairs.txt](https://github.com/user-attachments/files/18094084/diff-pairs.txt)

From the `framework` subdirectory with this pull request checked out, with https://github.com/Mbed-TLS/mbedtls/pull/9796 (3.6) checked out in the parent directory:
```
mbedtls-trace-files.py -b .. -f 1 $(git rev-parse ':/Create a framework')..HEAD $(./scripts/generate_psa_tests.py --list)
diff-pairs [0-9][0-9]-*/
ls -l [0-9][0-9]*.diff
```
Then for each `NN-SHA.diff` file, check that the content makes sense given the commit message for SHA.

With https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/ checked out in the parent, the following invocation of `mbedtls-trace-files.py` works:
```
mbedtls-trace-files.py --skip-make -r 'cd .. && framework/scripts/generate_psa_tests.py' -b .. -f 1 $(git rev-parse ':/Create a framework')..HEAD $(./scripts/generate_psa_tests.py --list)
diff-pairs [0-9][0-9]-*/
ls -l [0-9][0-9]*.diff
```

## PR checklist

- **crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/122
- **development PR** https://github.com/Mbed-TLS/mbedtls/pull/9841
- **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/9796

