### PR TITLE
all-core/helpers: Added support for libtestdriver post repo split

### DIFF
--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -157,14 +157,22 @@ pre_initialize_variables () {
             CRYPTO_CONFIG_H='tf-psa-crypto/include/psa/crypto_config.h'
             PSA_CORE_PATH='tf-psa-crypto/core'
             BUILTIN_SRC_PATH='tf-psa-crypto/drivers/builtin/src'
-            CONFIG_TEST_DRIVER_H='tf-psa-crypto/tests/configs/config_test_driver.h'
+            if in_3_6_branch; then
+                CONFIG_TEST_DRIVER_H='tf-psa-crypto/tests/configs/config_test_driver.h'
+            else
+                CONFIG_TEST_DRIVER_H='tf-psa-crypto/tests/configs/crypto_config_test_driver.h'
+            fi
         else
             CRYPTO_CONFIG_H='include/psa/crypto_config.h'
             # helper_armc6_build_test() relies on these being defined,
             # but empty if the paths don't exist (as in 3.6).
             PSA_CORE_PATH=''
             BUILTIN_SRC_PATH=''
-            CONFIG_TEST_DRIVER_H='tests/configs/config_test_driver.h'
+            if in_3_6_branch; then
+                CONFIG_TEST_DRIVER_H='tests/configs/config_test_driver.h'
+            else
+                CONFIG_TEST_DRIVER_H='tests/configs/crypto_config_test_driver.h'
+            fi
         fi
         config_files="$CONFIG_H $CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H"
     else

--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -153,26 +153,18 @@ pre_load_components () {
 pre_initialize_variables () {
     if in_mbedtls_repo; then
         CONFIG_H='include/mbedtls/mbedtls_config.h'
-        if [ -d tf-psa-crypto ]; then
-            CRYPTO_CONFIG_H='tf-psa-crypto/include/psa/crypto_config.h'
-            PSA_CORE_PATH='tf-psa-crypto/core'
-            BUILTIN_SRC_PATH='tf-psa-crypto/drivers/builtin/src'
-            if in_3_6_branch; then
-                CONFIG_TEST_DRIVER_H='tf-psa-crypto/tests/configs/config_test_driver.h'
-            else
-                CONFIG_TEST_DRIVER_H='tf-psa-crypto/tests/configs/crypto_config_test_driver.h'
-            fi
-        else
+        if in_3_6_branch; then
             CRYPTO_CONFIG_H='include/psa/crypto_config.h'
             # helper_armc6_build_test() relies on these being defined,
             # but empty if the paths don't exist (as in 3.6).
             PSA_CORE_PATH=''
             BUILTIN_SRC_PATH=''
-            if in_3_6_branch; then
-                CONFIG_TEST_DRIVER_H='tests/configs/config_test_driver.h'
-            else
-                CONFIG_TEST_DRIVER_H='tests/configs/crypto_config_test_driver.h'
-            fi
+            CONFIG_TEST_DRIVER_H='tests/configs/config_test_driver.h'
+        else
+            CRYPTO_CONFIG_H='tf-psa-crypto/include/psa/crypto_config.h'
+            PSA_CORE_PATH='tf-psa-crypto/core'
+            BUILTIN_SRC_PATH='tf-psa-crypto/drivers/builtin/src'
+            CONFIG_TEST_DRIVER_H='tf-psa-crypto/tests/configs/crypto_config_test_driver.h'
         fi
         config_files="$CONFIG_H $CRYPTO_CONFIG_H $CONFIG_TEST_DRIVER_H"
     else

--- a/scripts/all-helpers.sh
+++ b/scripts/all-helpers.sh
@@ -80,11 +80,19 @@ helper_libtestdriver1_adjust_config() {
     # If threading is enabled on the normal build, then we need to enable it in the drivers as well,
     # otherwise we will end up running multithreaded tests without mutexes to protect them.
     if scripts/config.py get MBEDTLS_THREADING_C; then
-        scripts/config.py -f "$CONFIG_TEST_DRIVER_H" set MBEDTLS_THREADING_C
+        if in_3_6_branch; then
+            scripts/config.py -f "$CONFIG_TEST_DRIVER_H" set MBEDTLS_THREADING_C
+        else
+            scripts/config.py -c "$CONFIG_TEST_DRIVER_H" set MBEDTLS_THREADING_C
+        fi
     fi
 
     if scripts/config.py get MBEDTLS_THREADING_PTHREAD; then
-        scripts/config.py -f "$CONFIG_TEST_DRIVER_H" set MBEDTLS_THREADING_PTHREAD
+        if in_3_6_branch; then
+            scripts/config.py -f "$CONFIG_TEST_DRIVER_H" set MBEDTLS_THREADING_PTHREAD
+        else
+            scripts/config.py -c "$CONFIG_TEST_DRIVER_H" set MBEDTLS_THREADING_PTHREAD
+        fi
     fi
 }
 


### PR DESCRIPTION
This pr changes the helper scripts to point to the ts-psa-crypto configuration file used after the repository split.

Development: https://github.com/Mbed-TLS/mbedtls/pull/9567
