### PR TITLE
Enable check_files.py for TF-PSA-Crypto

### DIFF
--- a/scripts/check_files.py
+++ b/scripts/check_files.py
@@ -371,10 +371,10 @@ class LicenseIssueTracker(LineIssueTracker):
     LICENSE_EXEMPTION_RE_LIST = []
 
     # Exempt third-party drivers which may be under a different license
-    if build_tree.is_mbedtls_3_6():
+    if build_tree.looks_like_tf_psa_crypto_root(os.getcwd()):
+        LICENSE_EXEMPTION_RE_LIST.append(r'drivers/(?=(everest)/.*)')
+    elif build_tree.is_mbedtls_3_6():
         LICENSE_EXEMPTION_RE_LIST.append(r'3rdparty/(?!(p256-m)/.*)')
-    else:
-        LICENSE_EXEMPTION_RE_LIST.append(r'(tf-psa-crypto/)?drivers/(?=(everest)/.*)')
 
     LICENSE_EXEMPTION_RE_LIST += [
         # Documentation explaining the license may have accidental

--- a/scripts/check_files.py
+++ b/scripts/check_files.py
@@ -374,7 +374,7 @@ class LicenseIssueTracker(LineIssueTracker):
     if build_tree.is_mbedtls_3_6():
         LICENSE_EXEMPTION_RE_LIST.append(r'3rdparty/(?!(p256-m)/.*)')
     else:
-        LICENSE_EXEMPTION_RE_LIST.append(r'tf-psa-crypto/drivers/(?=(everest)/.*)')
+        LICENSE_EXEMPTION_RE_LIST.append(r'(tf-psa-crypto/)?drivers/(?=(everest)/.*)')
 
     LICENSE_EXEMPTION_RE_LIST += [
         # Documentation explaining the license may have accidental
@@ -479,7 +479,8 @@ class IntegrityChecker:
         """Instantiate the sanity checker.
         Check files under the current directory.
         Write a report of issues to log_file."""
-        build_tree.check_repo_path()
+        if not build_tree.looks_like_root(os.getcwd()):
+            raise Exception("This script must be run from Mbed TLS or TF-PSA-Crypto root")
         self.logger = None
         self.setup_logger(log_file)
         self.issues_to_check = [


### PR DESCRIPTION
This commit enables check_files.py to run for Mbed TLS and TF-PSA-Crypto.

## PR checklist

Please add the numbers (or links) of the associated pull requests for consuming branches. You can omit branches where this pull request is not needed.

- [x] **crypto PR** Mbed-TLS/TF-PSA-Crypto: [#133](https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/133)
- [x] **development PR** Mbed-TLS/mbedtls# : Not required.
- [x] **3.6 PR** Mbed-TLS/mbedtls: Not required

## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
