### PR TITLE
Adapt check_names.py for independent TF-PSA-Crypto testing

### DIFF
--- a/scripts/check_names.py
+++ b/scripts/check_names.py
@@ -882,7 +882,6 @@ class MBEDTLSCodeParser(CodeParser):
             all_macros = {"public": [], "internal": [], "private":[]}
             all_macros["public"] = self.parse_macros([
                 "include/mbedtls/*.h",
-                "include/psa/*.h",
             ])
             all_macros["internal"] = self.parse_macros([
                 "library/*.h",
@@ -893,18 +892,15 @@ class MBEDTLSCodeParser(CodeParser):
             ])
             enum_consts = self.parse_enum_consts([
                 "include/mbedtls/*.h",
-                "include/psa/*.h",
                 "library/*.h",
                 "library/*.c",
             ])
             identifiers, excluded_identifiers = self.parse_identifiers([
                 "include/mbedtls/*.h",
-                "include/psa/*.h",
                 "library/*.h",
             ])
             mbed_psa_words = self.parse_mbed_psa_words([
                 "include/mbedtls/*.h",
-                "include/psa/*.h",
                 "library/*.h",
                 "library/*.c",
             ])

--- a/scripts/check_names.py
+++ b/scripts/check_names.py
@@ -222,7 +222,9 @@ class CodeParser():
         # Note that "*" can match directory separators in exclude lists.
         self.excluded_files = ["*/bn_mul", "*/compat-2.x.h"]
 
-    def _parse(self, all_macros, enum_consts, identifiers, excluded_identifiers, mbed_psa_words, symbols):
+    def _parse(self, all_macros, enum_consts, identifiers,
+               excluded_identifiers, mbed_psa_words, symbols):
+        # pylint: disable=too-many-arguments
         """
         Parse macros, enums, identifiers, excluded identifiers, Mbed PSA word and Symbols.
 
@@ -674,7 +676,7 @@ class CodeParser():
                     self.log.error(line)
         return symbols
 
-class TF_PSA_Crypto_CodeParser(CodeParser):
+class TFPSACryptoCodeParser(CodeParser):
     """
     Class for retrieving files and parsing TF-PSA-Crypto code. This can be used
     independently of the checks that NameChecker performs, for example for
@@ -750,7 +752,8 @@ class TF_PSA_Crypto_CodeParser(CodeParser):
         ], [self.source_dir + "/core/psa_crypto_driver_wrappers.h"])
         symbols = self.parse_symbols()
 
-        return self._parse(all_macros, enum_consts, identifiers, excluded_identifiers, mbed_psa_words, symbols)
+        return self._parse(all_macros, enum_consts, identifiers,
+                           excluded_identifiers, mbed_psa_words, symbols)
 
     def parse_symbols(self):
         """
@@ -821,7 +824,7 @@ class TF_PSA_Crypto_CodeParser(CodeParser):
 
         return symbols
 
-class MBEDTLS_CodeParser(CodeParser):
+class MBEDTLSCodeParser(CodeParser):
     """
     Class for retrieving files and parsing Mbed TLS code. This can be used
     independently of the checks that NameChecker performs, for example for
@@ -835,6 +838,7 @@ class MBEDTLS_CodeParser(CodeParser):
 
         Returns a dict of parsed item key to the corresponding List of Matches.
         """
+        all_macros = {"public": [], "internal": [], "private":[]}
         if build_tree.is_mbedtls_3_6():
             all_macros["public"] = self.parse_macros([
                 "include/mbedtls/*.h",
@@ -905,7 +909,8 @@ class MBEDTLS_CodeParser(CodeParser):
                 "library/*.c",
             ])
             symbols = self.parse_symbols()
-        return self._parse(all_macros, enum_consts, identifiers, excluded_identifiers, mbed_psa_words, symbols)
+        return self._parse(all_macros, enum_consts, identifiers,
+                           excluded_identifiers, mbed_psa_words, symbols)
 
     def parse_symbols(self):
         """
@@ -1161,13 +1166,13 @@ def main():
 
     try:
         if build_tree.looks_like_tf_psa_crypto_root(os.getcwd()):
-            tf_psa_crypto_code_parser = TF_PSA_Crypto_CodeParser(log)
+            tf_psa_crypto_code_parser = TFPSACryptoCodeParser(log)
             parse_result = tf_psa_crypto_code_parser.comprehensive_parse()
         elif build_tree.looks_like_mbedtls_root(os.getcwd()):
             # Mbed TLS uses TF-PSA-Crypto, so we need to parse TF-PSA-Crypto too
-            tf_psa_crypto_code_parser = TF_PSA_Crypto_CodeParser(log)
+            tf_psa_crypto_code_parser = TFPSACryptoCodeParser(log)
             tf_psa_crypto_parse_result = tf_psa_crypto_code_parser.comprehensive_parse()
-            mbedtls_code_parser = MBEDTLS_CodeParser(log)
+            mbedtls_code_parser = MBEDTLSCodeParser(log)
             mbedtls_parse_result = mbedtls_code_parser.comprehensive_parse()
             # Combine parse results together for NameChecker
             parse_result = {}

--- a/scripts/check_names.py
+++ b/scripts/check_names.py
@@ -8,12 +8,14 @@ This script confirms that the naming of all symbols and identifiers in Mbed TLS
 are consistent with the house style and are also self-consistent. It only runs
 on Linux and macOS since it depends on nm.
 
-It contains two major Python classes, CodeParser and NameChecker. They both have
-a comprehensive "run-all" function (comprehensive_parse() and perform_checks())
-but the individual functions can also be used for specific needs.
+It contains three major Python classes, TFPSACryptoCodeParser,
+MBEDTLSCodeParser and NameChecker. They all have a comprehensive "run-all"
+function (comprehensive_parse() and perform_checks()) but the individual
+functions can also be used for specific needs.
 
-CodeParser makes heavy use of regular expressions to parse the code, and is
-dependent on the current code formatting. Many Python C parser libraries require
+CodeParser(a inherent base class for TFPSACryptoCodeParser and MBEDTLSCodeParser)
+makes heavy use of regular expressions to parse the code, and is dependent on
+the current code formatting. Many Python C parser libraries require
 preprocessed C code, which means no macro parsing. Compiler tools are also not
 very helpful when we want the exact location in the original source (which
 becomes impossible when e.g. comments are stripped).
@@ -679,8 +681,7 @@ class CodeParser():
 class TFPSACryptoCodeParser(CodeParser):
     """
     Class for retrieving files and parsing TF-PSA-Crypto code. This can be used
-    independently of the checks that NameChecker performs, for example for
-    list_internal_identifiers.py.
+    independently of the checks that NameChecker performs.
     """
 
     def __init__(self, log):
@@ -827,8 +828,7 @@ class TFPSACryptoCodeParser(CodeParser):
 class MBEDTLSCodeParser(CodeParser):
     """
     Class for retrieving files and parsing Mbed TLS code. This can be used
-    independently of the checks that NameChecker performs, for example for
-    list_internal_identifiers.py.
+    independently of the checks that NameChecker performs.
     """
 
     def comprehensive_parse(self):


### PR DESCRIPTION
This commit separates CodeParser into three classes. CodeParser a base class containing methods for parsing .c and .h files as well as retrieving symbols from compiled libraries.

As well as two subclasses of CodeParser: TF-PSA-Crypto_CodeParser and MBEDTLS_CodeParser, which are responsible for parsing the TF-PSA-Crypto and Mbed TLS libraries.

## PR checklist

Please add the numbers (or links) of the associated pull requests for consuming branches. You can omit branches where this pull request is not needed.

- [ ] **crypto PR** Mbed-TLS: [#143](https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/143)
- [ ] **development PR** Mbed-TLS: [#9915](https://github.com/Mbed-TLS/mbedtls/pull/9915)
- [ ] **3.6 PR** Mbed-TLS/mbedtls#

## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
