### PR TITLE
Fix framework CI against mbedtls-3.6

### DIFF
--- a/data_files/.gitignore
+++ b/data_files/.gitignore
@@ -2,7 +2,7 @@ cli-rsa.csr
 server2-rsa.csr
 test-ca.csr
 
-/data_files/mpi_write
-/data_files/hmac_drbg_seed
-/data_files/ctr_drbg_seed
-/data_files/entropy_seed
+mpi_write
+hmac_drbg_seed
+ctr_drbg_seed
+entropy_seed

--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -938,7 +938,7 @@ run_component () {
     esac
     "${dd_cmd[@]}"
 
-    if [ -d tf-psa-crypto ]; then
+    if in_mbedtls_repo && in_4_x_branch; then
         dd_cmd=(dd if=/dev/urandom of=./tf-psa-crypto/tests/seedfile bs=64 count=1)
         case $OSTYPE in
             linux*|freebsd*|openbsd*) dd_cmd+=(status=none)

--- a/scripts/mbedtls_framework/build_tree.py
+++ b/scripts/mbedtls_framework/build_tree.py
@@ -44,10 +44,10 @@ def crypto_core_directory(root: Optional[str] = None, relative: Optional[bool] =
             return "core"
         return os.path.join(root, "core")
     elif looks_like_mbedtls_root(root):
-        if os.path.isdir(os.path.join(root, 'tf-psa-crypto')):
-            path = "tf-psa-crypto/core"
-        else:
+        if is_mbedtls_3_6():
             path = "library"
+        else:
+            path = "tf-psa-crypto/core"
         if relative:
             return path
         return os.path.join(root, path)

--- a/scripts/mbedtls_framework/code_wrapper/psa_wrapper.py
+++ b/scripts/mbedtls_framework/code_wrapper/psa_wrapper.py
@@ -106,7 +106,7 @@ class PSAWrapper(c_wrapper_generator.Base):
         # Temporary, while Mbed TLS does not just rely on the TF-PSA-Crypto
         # build system to build its crypto library. When it does, the first
         # case can just be removed.
-        if os.path.isdir(os.path.join(self.mbedtls_root, 'tf-psa-crypto')):
+        if not build_tree.is_mbedtls_3_6():
             path_list = ['tf-psa-crypto' ] + path_list
             return os.path.join(self.mbedtls_root, *path_list, filename)
 

--- a/scripts/mbedtls_framework/psa_information.py
+++ b/scripts/mbedtls_framework/psa_information.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 #
 
-import os
 import re
 from collections import OrderedDict
 from typing import List, Optional

--- a/scripts/mbedtls_framework/psa_information.py
+++ b/scripts/mbedtls_framework/psa_information.py
@@ -10,6 +10,7 @@ import re
 from collections import OrderedDict
 from typing import List, Optional
 
+from . import build_tree
 from . import macro_collector
 
 
@@ -36,17 +37,17 @@ class Information:
     def read_psa_interface(self) -> macro_collector.PSAMacroEnumerator:
         """Return the list of known key types, algorithms, etc."""
         constructors = macro_collector.InputsForTest()
-        # Temporary, while Mbed TLS does not just rely on the TF-PSA-Crypto
-        # build system to build its crypto library. When it does, the first
-        # case can just be removed.
-        if os.path.isdir('tf-psa-crypto'):
-            header_file_names = ['tf-psa-crypto/include/psa/crypto_values.h',
-                                 'tf-psa-crypto/include/psa/crypto_extra.h']
-            test_suites = ['tf-psa-crypto/tests/suites/test_suite_psa_crypto_metadata.data']
-        else:
-            header_file_names = ['include/psa/crypto_values.h',
-                                 'include/psa/crypto_extra.h']
-            test_suites = ['tests/suites/test_suite_psa_crypto_metadata.data']
+
+        if build_tree.looks_like_root('.'):
+            if build_tree.looks_like_mbedtls_root('.') and \
+               (not build_tree.is_mbedtls_3_6()):
+                header_file_names = ['tf-psa-crypto/include/psa/crypto_values.h',
+                                     'tf-psa-crypto/include/psa/crypto_extra.h']
+                test_suites = ['tf-psa-crypto/tests/suites/test_suite_psa_crypto_metadata.data']
+            else:
+                header_file_names = ['include/psa/crypto_values.h',
+                                     'include/psa/crypto_extra.h']
+                test_suites = ['tests/suites/test_suite_psa_crypto_metadata.data']
 
         for header_file_name in header_file_names:
             constructors.parse_header(header_file_name)

--- a/scripts/mbedtls_framework/psa_storage.py
+++ b/scripts/mbedtls_framework/psa_storage.py
@@ -10,7 +10,6 @@ before changing how test data is constructed or validated.
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 #
 
-import os
 import re
 import struct
 from typing import Dict, List, Optional, Set, Union

--- a/scripts/mbedtls_framework/psa_storage.py
+++ b/scripts/mbedtls_framework/psa_storage.py
@@ -45,21 +45,17 @@ class Expr:
         # Temporary, while Mbed TLS does not just rely on the TF-PSA-Crypto
         # build system to build its crypto library. When it does, the first
         # case can just be removed.
-        if os.path.isdir('tf-psa-crypto'):
-            includes = ['include', 'tf-psa-crypto/include',
-                        'tf-psa-crypto/drivers/builtin/include',
-                        'tf-psa-crypto/drivers/everest/include']
-        else:
-            includes = ['include']
 
-        if build_tree.looks_like_tf_psa_crypto_root('.'):
-            includes.append('drivers/builtin/include')
-            includes.append('drivers/everest/include')
-            # Temporary, while TF-PSA-Crypto build system in Mbed TLS still
-            # reference some files in Mbed TLS include directory. When it does
-            # not anymore, this can be removed.
-            if build_tree.looks_like_mbedtls_root('..'):
-                includes.append('../include')
+        if build_tree.looks_like_root('.'):
+            includes = ['include']
+            if build_tree.looks_like_tf_psa_crypto_root('.'):
+                includes.append('drivers/builtin/include')
+                includes.append('drivers/everest/include')
+            elif not build_tree.is_mbedtls_3_6():
+                includes.append('tf-psa-crypto/include')
+                includes.append('tf-psa-crypto/drivers/builtin/include')
+                includes.append('tf-psa-crypto/drivers/everest/include')
+
         values = c_build_helper.get_c_expression_values(
             'unsigned long', '%lu',
             expressions,

--- a/scripts/mbedtls_framework/psa_test_case.py
+++ b/scripts/mbedtls_framework/psa_test_case.py
@@ -9,6 +9,7 @@ import os
 import re
 from typing import FrozenSet, List, Optional, Set
 
+from . import build_tree
 from . import psa_information
 from . import test_case
 
@@ -33,10 +34,14 @@ def find_dependencies_not_implemented(dependencies: List[str]) -> List[str]:
         # Temporary, while Mbed TLS does not just rely on the TF-PSA-Crypto
         # build system to build its crypto library. When it does, the first
         # case can just be removed.
-        if os.path.isdir('tf-psa-crypto'):
-            include_dir = 'tf-psa-crypto/include'
-        else:
-            include_dir = 'include'
+
+        if build_tree.looks_like_root('.'):
+            if build_tree.looks_like_mbedtls_root('.') and \
+               (not build_tree.is_mbedtls_3_6()):
+                include_dir = 'tf-psa-crypto/include'
+            else:
+                include_dir = 'include'
+
         acc = set() #type: Set[str]
         for filename in [
                 os.path.join(include_dir, 'psa/crypto_config.h'),


### PR DESCRIPTION
## Description
Fix the framework CI against mbedtls-3.6
To distinguish between mbedtls development and 3.6, use build_tree module instead of checking the existence or not the tf-psa-crypto directory. We need that for framework CI against mbedtls-3.6 as an empty tf-psa-crypto is present in that case.

## PR checklist

Please add the numbers (or links) of the associated pull requests for consuming branches. You can omit branches where this pull request is not needed.

- [x] **crypto PR** Mbed-TLS/TF-PSA-Crypto#156
- [x] **development PR** none
- [x] **3.6 PR** none