### PR TITLE
Add consistency checks to mbedtls_test_psa_raw_key_agreement_with_self()

### DIFF
--- a/tests/include/test/psa_exercise_key.h
+++ b/tests/include/test/psa_exercise_key.h
@@ -138,11 +138,22 @@ int mbedtls_test_psa_setup_key_derivation_wrap(
     size_t capacity, int key_destroyable);
 
 /** Perform a key agreement using the given key pair against its public key
- * using psa_raw_key_agreement() and psa_key_agreement().
+ * (not combined with a key derivation).
  *
- * The result is discarded. The purpose of this function is to smoke-test a key.
+ * The result is discarded. Thus this function can be used for smoke-testing
+ * a key, and to validate input validation, but not to validate results.
  *
- * In case of failure, mark the current test case as failed.
+ * Depending on the library version, there can be multiple interfaces for key
+ * agreement. This test function performs the ones that are available amongst:
+ * - psa_raw_key_agreement()
+ * - psa_key_agreement()
+ * - psa_key_agreement_iop_setup() and psa_key_agreement_iop_complete()
+ *
+ * Mark the current test case as failed in the following cases:
+ * - Operational errors such as failure to allocate memory for an intermediate
+ *   buffer.
+ * - Results are not consistent between the methods that are performed:
+ *   different statuses, or inconsistent metadata, or different shared secret.
  *
  * \param alg               A key agreement algorithm compatible with \p key.
  * \param key               A key that allows key agreement with \p alg.
@@ -150,7 +161,7 @@ int mbedtls_test_psa_setup_key_derivation_wrap(
  *                          or the key being destroyed mid-operation will only
  *                          be reported if the error code is unexpected.
  *
- * \return                  \c 1 on success, \c 0 on failure.
+ * \return                  The status from psa_raw_key_agreement().
  */
 psa_status_t mbedtls_test_psa_raw_key_agreement_with_self(
     psa_algorithm_t alg,

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -780,13 +780,14 @@ psa_status_t mbedtls_test_psa_raw_key_agreement_with_self(
         TEST_CALLOC(exported, exported_size);
 
         status = psa_export_key(shared_secret_id, exported, exported_size, &exported_length);
-
         if (key_destroyable && status == PSA_ERROR_INVALID_HANDLE) {
             /* The key has been destroyed. */
             status = PSA_SUCCESS;
+        } else {
+            PSA_ASSERT(status);
+            TEST_MEMORY_COMPARE(exported, exported_length,
+                                output, output_length);
         }
-
-        PSA_ASSERT(status);
     }
 
  #if defined(MBEDTLS_ECP_RESTARTABLE) && defined(MBEDTLS_PSA_BUILTIN_ALG_ECDH)
@@ -823,9 +824,18 @@ psa_status_t mbedtls_test_psa_raw_key_agreement_with_self(
             if (key_destroyable && status == PSA_ERROR_INVALID_HANDLE) {
                 /* The key has been destroyed. */
                 status = PSA_SUCCESS;
+            } else {
+                PSA_ASSERT(status);
+                status = psa_export_key(shared_secret_id, exported, exported_size, &exported_length);
+                if (key_destroyable && status == PSA_ERROR_INVALID_HANDLE) {
+                    /* The key has been destroyed. */
+                    status = PSA_SUCCESS;
+                } else {
+                    PSA_ASSERT(status);
+                    TEST_MEMORY_COMPARE(exported, exported_length,
+                                        output, output_length);
+                }
             }
-
-            PSA_ASSERT(status);
         }
     } else {
         TEST_EQUAL(psa_key_agreement_iop_setup(&iop_operation, key, public_key,


### PR DESCRIPTION
In `mbedtls_test_psa_raw_key_agreement_with_self()`, we may use up to three key agreement methods: `psa_raw_key_agreement()`, `psa_key_agreement()`, and the interruptible interface. Check that all three have the same status and output.

I discovered the problem while working on https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/157. These test improvements are not necessary to get the CI to pass there, but they are useful to validate https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/157, so I consider them a required (if unplanned) part of the task.

Note that until https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/157 is merged, the CI may fail.

## PR checklist

- [x] **crypto PR** no consumer
- [x] **development PR** no consumer
- [x] **3.6 PR** no consumer
