### PR TITLE
Log build steps in the outcome file

### DIFF
--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -790,6 +790,19 @@ pre_prepare_outcome_file () {
     fi
 }
 
+## write_outcome_line SUITE CASE RESULT [CAUSE]
+## Write a line in the outcome file if enabled.
+## Report $MBEDTLS_TEST_PLATFORM, $MBEDTLS_TEST_CONFIGURATION and the
+## supplied arguments.
+write_outcome_line () {
+    if [ -z "$MBEDTLS_TEST_OUTCOME_FILE" ]; then
+        return
+    fi
+    printf '%s;%s;%s;%s;%s;%s\n' >>"$MBEDTLS_TEST_OUTCOME_FILE" \
+           "$MBEDTLS_TEST_PLATFORM" "$MBEDTLS_TEST_CONFIGURATION" \
+           "$1" "$2" "$3" "${4-}"
+}
+
 pre_print_configuration () {
     if [ $QUIET -eq 1 ]; then
         return
@@ -981,6 +994,12 @@ run_component () {
         if [ $component_status -ne 0 ]; then
             failure_count=$((failure_count + 1))
         fi
+    fi
+
+    if [ $component_status -eq 0 ]; then
+        write_outcome_line "all.sh" "whole" "PASS"
+    else
+        write_outcome_line "all.sh" "whole" "FAIL" "$component_status"
     fi
 
     # Restore the build tree to a clean state.

--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -208,6 +208,9 @@ pre_initialize_variables () {
     # Specify character collation for regular expressions and sorting with C locale
     export LC_COLLATE=C
 
+    # Make the location of the root directory available to reporting scripts
+    export MBEDTLS_TEST_ROOT="$PWD"
+
     : ${MBEDTLS_TEST_OUTCOME_FILE=}
     : ${MBEDTLS_TEST_PLATFORM="$(uname -s | tr -c \\n0-9A-Za-z _)-$(uname -m | tr -c \\n0-9A-Za-z _)"}
     export MBEDTLS_TEST_OUTCOME_FILE

--- a/scripts/quiet/make
+++ b/scripts/quiet/make
@@ -58,10 +58,10 @@ log_outcome () {
     cause= # Identifying failure causes would be nice, but difficult
 
     for target in $targets; do
-        if [ "$target" = "clean" ]; then
-            # Boring
-            continue
-        fi
+        case "$target" in
+            "clean"|"neat") continue;; # Boring
+            cmTC_*) continue;; # Weirdness from CMake
+        esac
         echo >>"${MBEDTLS_TEST_OUTCOME_FILE}" \
              "${MBEDTLS_TEST_PLATFORM};${MBEDTLS_TEST_CONFIGURATION};${TOOL};${target};${result};${cause}"
     done

--- a/scripts/quiet/make
+++ b/scripts/quiet/make
@@ -28,6 +28,8 @@ log_outcome () {
             continue
         fi
         case $arg in
+            --question|-q) # do-nothing option
+                return;;
             --assume-new|--assume-old|--directory|--file| \
             --include-dir|--makefile|--new-file|--old-file|--what-if| \
             -C|-I|-W|-f|-k|-o) # Option with separate argument

--- a/scripts/quiet/make
+++ b/scripts/quiet/make
@@ -17,3 +17,59 @@ NO_SILENCE=" --version | test "
 TOOL="make"
 
 . "$(dirname "$0")/quiet.sh"
+EXIT_STATUS=$?
+
+log_outcome () {
+    targets=
+    skip=
+    for arg in "$@"; do
+        if [ -n "$skip" ]; then
+            skip=
+            continue
+        fi
+        case $arg in
+            --assume-new|--assume-old|--directory|--file| \
+            --include-dir|--makefile|--new-file|--old-file|--what-if| \
+            -C|-I|-W|-f|-k|-o) # Option with separate argument
+                skip=1; continue;;
+            -*) continue;; # Option
+            *=*) continue;; # Variable assignment
+            *[!-+./0-9@A-Z_a-z]*) # Target with problematic character
+                targets="$targets ${arg%%[!-+./0-9@A-Z_a-z]*}...";;
+            *) # Normal target
+                targets="$targets $arg";;
+        esac
+    done
+    if [ -n "$targets" ]; then
+        targets=${targets# }
+    else
+        targets=all
+    fi
+
+    # We have a single pass/fail status. This is not accurate when there are
+    # multiple targets: it's possible that some passed and some failed.
+    # To figure out which targets passed when the overall result is a failure,
+    # we'd have to do some complex parsing of logs.
+    if [ $EXIT_STATUS -eq 0 ]; then
+        result=PASS
+    else
+        result=FAIL
+    fi
+    cause= # Identifying failure causes would be nice, but difficult
+
+    for target in $targets; do
+        if [ "$target" = "clean" ]; then
+            # Boring
+            continue
+        fi
+        echo >>"${MBEDTLS_TEST_OUTCOME_FILE}" \
+             "${MBEDTLS_TEST_PLATFORM};${MBEDTLS_TEST_CONFIGURATION};${TOOL};${target};${result};${cause}"
+    done
+}
+
+if [ -n "${MBEDTLS_TEST_OUTCOME_FILE}" ] &&
+   [ -n "${MBEDTLS_TEST_CONFIGURATION}" ]; then
+    log_outcome "$@"
+fi
+
+exit $EXIT_STATUS

--- a/scripts/quiet/make
+++ b/scripts/quiet/make
@@ -20,21 +20,36 @@ TOOL="make"
 EXIT_STATUS=$?
 
 log_outcome () {
+    # Options passed to make indicating that a different makefile is used
+    modifier=
+    # Space-separated list of targets
     targets=
+    # Temporary variable used in the loop after an option that takes an argument
     skip=
+
     for arg in "$@"; do
         if [ -n "$skip" ]; then
+            if [ "$skip" = "modifier" ]; then
+                modifier="$modifier$arg "
+            fi
             skip=
             continue
         fi
+
         case $arg in
-            --question|-q) # do-nothing option
+            --dry-run|--help|--just-print|--question|--recon|--version|-n|-q|-v)
+                # do-nothing option
                 return;;
-            --assume-new|--assume-old|--directory|--file| \
+            --directory=*|--file=*|-C?*|-f?*) # Modifier option with its argument
+                modifier="$modifier$arg ";;
+            --directory|--file|-C|-f) # Modifier option with separate argument
+                skip=modifier
+                modifier="$modifier$arg ";;
+            --assume-new|--assume-old| \
             --include-dir|--makefile|--new-file|--old-file|--what-if| \
-            -C|-I|-W|-f|-k|-o) # Option with separate argument
+            -I|-W|-k|-o) # Boring option with separate argument
                 skip=1; continue;;
-            -*) continue;; # Option
+            -*) continue;; # Other option (assumed boring)
             *=*) continue;; # Variable assignment
             *[!-+./0-9@A-Z_a-z]*) # Target with problematic character
                 targets="$targets ${arg%%[!-+./0-9@A-Z_a-z]*}...";;
@@ -42,9 +57,23 @@ log_outcome () {
                 targets="$targets $arg";;
         esac
     done
+
+    if [ -n "$MBEDTLS_TEST_ROOT" ] && [ "$MBEDTLS_TEST_ROOT" != "$PWD" ]; then
+        # Record that `make` was run in a different directory.
+        # This is only accurate when run by all.sh (or more generally
+        # if $MBEDTLS_TEST_ROOT is set in the environment).
+        case "$PWD" in
+            "$MBEDTLS_TEST_ROOT/"*) modifier="-C ${PWD#"${MBEDTLS_TEST_ROOT}/"} $modifier";;
+            *) modifier="-C $PWD $modifier";;
+        esac
+    fi
+
     if [ -n "$targets" ]; then
         targets=${targets# }
     else
+        # Assume that the default target is "all". This is true for
+        # the toplevel Makefile and when using CMake, but might not be
+        # true when using a different makefile.
         targets=all
     fi
 

--- a/scripts/quiet/quiet.sh
+++ b/scripts/quiet/quiet.sh
@@ -59,7 +59,7 @@ fi
 
 if [[ " $@ " =~ $NO_SILENCE || -n "${VERBOSE_LOGS}" ]]; then
     # Run original command with no output supression
-    exec "${ORIGINAL_TOOL}" "$@"
+    "${ORIGINAL_TOOL}" "$@"
 else
     # Run original command and capture output & exit status
     TMPFILE=$(mktemp "quiet-${TOOL}.XXXXXX")
@@ -75,5 +75,6 @@ else
     rm "${TMPFILE}"
 
     # Propagate the exit status
-    exit $EXIT_STATUS
+    set_status () { return $1; }
+    set_status $EXIT_STATUS
 fi


### PR DESCRIPTION
Add some logging to the output file:

* `make` invocation (including CMake-driven builds): `"${MBEDTLS_TEST_PLATFORM};${MBEDTLS_TEST_CONFIGURATION};${TOOL};${target};${result};${cause}"`
* for each component: `"${MBEDTLS_TEST_PLATFORM};${component_name};all.sh;whole;${result};"`

Extracted from https://github.com/Mbed-TLS/mbedtls/pull/9286.

This is supposed to be transparent for a consuming branch, so we can merge it at our leisure.

## PR checklist

Please add the numbers (or links) of the associated pull requests for consuming branches. You can omit branches where this pull request is not needed.

- [x] **crypto PR** not needed
- [x] **development PR** not needed
- [x] **3.6 PR** not needed
- [x] **2.28 PR** no: we won't bother to backport this to a branch that's almost out of support.
