### PR TITLE
tests: fix overlength buffer

### DIFF
--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -184,7 +184,7 @@ static int exercise_cipher_key(mbedtls_svc_key_id_t key,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_type_t key_type;
     const unsigned char plaintext[16] = "Hello, world...";
-    unsigned char ciphertext[32] = "(wabblewebblewibblewobblewubble)";
+    unsigned char ciphertext[] = "(wabblewebblewibblewobblewubble)";
     size_t ciphertext_length = sizeof(ciphertext);
     unsigned char decrypted[sizeof(ciphertext)];
     size_t part_length;


### PR DESCRIPTION
The buffer was defined as 32 characters, but the string was 33 characters when including the NULL byte.

This led to build errors on Fedora:
/builddir/build/BUILD/mbedtls3.6-3.6.2-build/mbedtls-3.6.2/tests/src/psa_exercise_key.c:186:36: error: initializer-string for array of ‘unsigned char’ is too long [-Werror=unterminated-string-initialization]
  186 |     unsigned char ciphertext[32] = "(wabblewebblewibblewobblewubble)";

Fix this by leaving out the size portion of the array definition becuase C89 allows this.

## Description

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2340827

## PR checklist

Please add the numbers (or links) of the associated pull requests for consuming branches. You can omit branches where this pull request is not needed.

- [ ] **crypto PR** Mbed-TLS/TF-PSA-Crypto#
- [ ] **development PR** Mbed-TLS/mbedtls#
- [ ] **3.6 PR** Mbed-TLS/mbedtls#



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
