### PR TITLE
PR-Template: Updated the PR template with TF-PSA-Crypto checkbox

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,9 +8,9 @@ Please write a few sentences describing the overall goals of the pull request's 
 
 Please add the numbers (or links) of the associated pull requests for consuming branches. You can omit branches where this pull request is not needed.
 
-- [ ] **crypto PR** Mbed-TLS/TF-PSA-Crypto#
-- [ ] **development PR** Mbed-TLS/mbedtls#
-- [ ] **3.6 PR** Mbed-TLS/mbedtls#
+- [ ] **TF-PSA-Crypto PR** provided # | not required because: 
+- [ ] **development PR** provided # | not required because: 
+- [ ] **3.6 PR** provided # | not required because: 
 
 
 


### PR DESCRIPTION
## Description

This PR is changing the name of the TF-PSA-Crypto link in the chekcboxes to keep it consistent with the other repositories. We are usng the name of the repository as the label indicator.

[MbedTLS -> TF-PSA-Crypto](https://github.com/Mbed-TLS/mbedtls/blob/d5c8bf0f093a484b50aa07836fb65ef592d6d93d/.github/pull_request_template.md?plain=1#L14)
[TF-PSA-Crypto --> mbedtls](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/development/.github/pull_request_template.md?plain=1#L14)


Please also see [#9945](https://github.com/Mbed-TLS/mbedtls/pull/9945)

