### PR TITLE
Incremental TLS handshake defragmentation tests

### DIFF
--- a/scripts/generate_tls_handshake_tests.py
+++ b/scripts/generate_tls_handshake_tests.py
@@ -120,8 +120,9 @@ def write_tls_handshake_defragmentation_test(
         ]
 
     if cipher is not None:
+        mbedtls_cipher = translate_ciphers.translate_mbedtls(cipher)
         if side == Side.CLIENT:
-            our_args += ' force_ciphersuite=' + translate_ciphers.translate_mbedtls(cipher)
+            our_args += ' force_ciphersuite=' + mbedtls_cipher
             if 'NULL' in cipher:
                 their_args += ' -cipher ALL@SECLEVEL=0:COMPLEMENTOFALL@SECLEVEL=0'
         else:
@@ -129,7 +130,7 @@ def write_tls_handshake_defragmentation_test(
             # cipher suite on the client side, because passing
             # force_ciphersuite to ssl_server2 would force a TLS-1.2-only
             # server, which does not support a fragmented ClientHello.
-            tc.requirements.append('requires_ciphersuite_enabled ' + cipher)
+            tc.requirements.append('requires_ciphersuite_enabled ' + mbedtls_cipher)
             their_args += ' -cipher ' + translate_ciphers.translate_ossl(cipher)
             if 'NULL' in cipher:
                 their_args += '@SECLEVEL=0'

--- a/scripts/generate_tls_handshake_tests.py
+++ b/scripts/generate_tls_handshake_tests.py
@@ -104,7 +104,6 @@ def write_tls_handshake_defragmentation_test(
 
     if length is None:
         forbidden_patterns = [
-            'reassembled record',
             'waiting for more fragments',
         ]
         wanted_patterns = []

--- a/scripts/generate_tls_handshake_tests.py
+++ b/scripts/generate_tls_handshake_tests.py
@@ -113,7 +113,8 @@ def write_tls_handshake_defragmentation_test(
         forbidden_patterns = []
         wanted_patterns = [
             'reassembled record',
-            fr'handshake fragment: {length}, 0\.\.{length} of [0-9]\+',
+            fr'initial handshake fragment: {length}, 0\.\.{length} of [0-9]\+',
+            fr'subsequent handshake fragment: [0-9]\+, {length}\.\.',
             fr'Prepare: waiting for more handshake fragments {length}/',
             fr'Consume: waiting for more handshake fragments {length}/',
         ]

--- a/scripts/generate_tls_handshake_tests.py
+++ b/scripts/generate_tls_handshake_tests.py
@@ -56,17 +56,6 @@ def write_tls_handshake_defragmentation_test(
     description = f'Handshake defragmentation on {side.name.lower()}: {description}'
     tc = tls_test_case.TestCase(description)
 
-    if version == Version.TLS12 and \
-       length is not None and \
-       length >= TLS_HANDSHAKE_FRAGMENT_MIN_LENGTH and \
-       length < 16 and \
-       side == side.CLIENT:
-        # Skip test cases where the Finished message is fragmented in TLS 1.2.
-        # This is currently buggy when the symmetric encryption used an
-        # explicit IV (CBC, GCM or CCM; Chachapoly and null work, as does
-        # TLS 1.3, because they use a purely implicit IV).
-        tc.requirements.append('skip_next_test')
-
     if version is not None:
         their_args += ' ' + version.openssl_option()
         # Emit a version requirement, because we're forcing the version via

--- a/scripts/generate_tls_handshake_tests.py
+++ b/scripts/generate_tls_handshake_tests.py
@@ -80,7 +80,7 @@ def write_tls_handshake_defragmentation_test(
             # or at runtime), the TLS 1.2 ClientHello parser only sees
             # the first fragment of the ClientHello.
             tc.requirements.append('requires_config_enabled MBEDTLS_SSL_PROTO_TLS1_3')
-            tc.description += '  TLS 1.3 ClientHello -> 1.2 Handshake'
+            tc.description += ' with 1.3 support'
 
     # To guarantee that the handhake messages are large enough and need to be
     # split into fragments, the tests require certificate authentication.

--- a/scripts/generate_tls_handshake_tests.py
+++ b/scripts/generate_tls_handshake_tests.py
@@ -14,9 +14,8 @@ from typing import Optional
 
 from mbedtls_framework import tls_test_case
 from mbedtls_framework import typing_util
-import translate_ciphers
-
 from mbedtls_framework.tls_test_case import Side, Version
+import translate_ciphers
 
 
 # Assume that a TLS 1.2 ClientHello used in these tests will be at most
@@ -27,6 +26,7 @@ TLS12_CLIENT_HELLO_ASSUMED_MAX_LENGTH = 255
 TLS_HANDSHAKE_FRAGMENT_MIN_LENGTH = 4
 
 def write_tls_handshake_defragmentation_test(
+        #pylint: disable=too-many-arguments
         out: typing_util.Writable,
         side: Side,
         length: Optional[int],

--- a/scripts/generate_tls_handshake_tests.py
+++ b/scripts/generate_tls_handshake_tests.py
@@ -125,8 +125,9 @@ def write_tls_handshake_defragmentation_test(
         forbidden_patterns = []
         wanted_patterns = [
             'reassembled record',
-            fr'handshake fragment: 0 \.\. {length} of [0-9]\+ msglen {length}',
-            fr'waiting for more fragments ({length} of',
+            fr'handshake fragment: {length}, 0\.\.{length} of [0-9]\+',
+            fr'Prepare: waiting for more handshake fragments {length}/',
+            fr'Consume: waiting for more handshake fragments {length}/',
         ]
 
     if cipher is not None:


### PR DESCRIPTION
Tweaked some tests and added a few more for https://github.com/Mbed-TLS/mbedtls/pull/10011.

Status: Continues from https://github.com/Mbed-TLS/mbedtls-framework/pull/142. The first new commit is "Clarify test case description".

## PR checklist

- [x] **changelog** not required because: fixes unreleased bug
- [x] **development PR** https://github.com/Mbed-TLS/mbedtls/pull/10011
- [x] **TF-PSA-Crypto PR** not required because: TLS only
- [x] **framework PR** here
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10030
- [x] **2.28 PR** not required because: feature not in 2.28
- **tests**  provided
