### PR TITLE
[framework] Make mbedtls_psa_register_se_key usable with opaque drivers

### DIFF
--- a/tests/include/test/drivers/key_management.h
+++ b/tests/include/test/drivers/key_management.h
@@ -16,6 +16,10 @@
 #define PSA_CRYPTO_TEST_DRIVER_BUILTIN_AES_KEY_SLOT     0
 #define PSA_CRYPTO_TEST_DRIVER_BUILTIN_ECDSA_KEY_SLOT   1
 
+extern const uint8_t mbedtls_test_driver_aes_key[16];
+extern const uint8_t mbedtls_test_driver_ecdsa_key[32];
+extern const uint8_t mbedtls_test_driver_ecdsa_pubkey[65];
+
 typedef struct {
     /* If non-null, on success, copy this to the output. */
     void *forced_output;


### PR DESCRIPTION
## Description

This helps resolving https://github.com/Mbed-TLS/mbedtls/issues/9255

## PR checklist

- [ ] **TF-PSA-Crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/191
- [ ] **development PR** https://github.com/Mbed-TLS/mbedtls/pull/10041
- [ ] **3.6 PR** no