### PR TITLE
fix: Allow encrypt key usage for a CMAC operation

### DIFF
--- a/scripts/mbedtls_framework/crypto_knowledge.py
+++ b/scripts/mbedtls_framework/crypto_knowledge.py
@@ -548,7 +548,8 @@ class Algorithm:
             flags = []
         elif self.category == AlgorithmCategory.MAC:
             flags = ['SIGN_HASH', 'SIGN_MESSAGE',
-                     'VERIFY_HASH', 'VERIFY_MESSAGE']
+                     'VERIFY_HASH', 'VERIFY_MESSAGE',
+                     'ENCRYPT']
         elif self.category == AlgorithmCategory.CIPHER or \
              self.category == AlgorithmCategory.AEAD:
             flags = ['DECRYPT', 'ENCRYPT']


### PR DESCRIPTION
## Description

The key that would be used for MAC operations using CMAC should also have the `PSA_KEY_USAGE_ENCRYPT` flag set. CMAC operation internally performs AES/DES encryption thus the key that is used should have the `PSA_KEY_USAGE_ENCRYPT` flag set.

Currently this is not an issue because the `psa_mac_` APIs do not invoke `psa_cipher_` API calls thus PSA key usage is not checked during the cipher operation that takes place internally. IMO ideally the `psa_mac_` APIs should internally call the `psa_cipher_` layer which would check the usage flags of the key, and thus we would need to set the `PSA_KEY_USAGE_ENCRYPT` flag.

## Related

https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/211

This PR is needed for: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/249

## PR checklist

Please add the numbers (or links) of the associated pull requests for consuming branches. You can omit branches where this pull request is not needed.

- [X] **TF-PSA-Crypto PR** provided:  
- [X] **3.6 PR** not required.