### PR TITLE
Adjust scripts to accommodate public header move

### DIFF
--- a/scripts/check-doxy-blocks.pl
+++ b/scripts/check-doxy-blocks.pl
@@ -18,6 +18,7 @@ use File::Basename;
 # C/header files in the following directories will be checked
 my @mbedtls_directories = qw(include/mbedtls library doxygen/input);
 my @tf_psa_crypto_directories = qw(include/psa include/tf-psa-crypto
+                                   include/mbedtls
                                    drivers/builtin/include/mbedtls
                                    drivers/builtin/src core doxygen/input);
 

--- a/scripts/check_names.py
+++ b/scripts/check_names.py
@@ -701,6 +701,7 @@ class TFPSACryptoCodeParser(CodeParser):
         all_macros["public"] = self.parse_macros([
             "include/psa/*.h",
             "include/tf-psa-crypto/*.h",
+            "include/mbedtls/*.h",
             "drivers/builtin/include/mbedtls/*.h",
             "drivers/everest/include/everest/everest.h",
             "drivers/everest/include/everest/x25519.h"
@@ -717,6 +718,7 @@ class TFPSACryptoCodeParser(CodeParser):
         enum_consts = self.parse_enum_consts([
             "include/psa/*.h",
             "include/tf-psa-crypto/*.h",
+            "include/mbedtls/*.h",
             "drivers/builtin/include/mbedtls/*.h",
             "core/*.h",
             "drivers/builtin/src/*.h",
@@ -728,6 +730,7 @@ class TFPSACryptoCodeParser(CodeParser):
         identifiers, excluded_identifiers = self.parse_identifiers([
             "include/psa/*.h",
             "include/tf-psa-crypto/*.h",
+            "include/mbedtls/*.h",
             "drivers/builtin/include/mbedtls/*.h",
             "core/*.h",
             "drivers/builtin/src/*.h",
@@ -737,6 +740,7 @@ class TFPSACryptoCodeParser(CodeParser):
         mbed_psa_words = self.parse_mbed_psa_words([
             "include/psa/*.h",
             "include/tf-psa-crypto/*.h",
+            "include/mbedtls/*.h",
             "drivers/builtin/include/mbedtls/*.h",
             "core/*.h",
             "drivers/builtin/src/*.h",


### PR DESCRIPTION
Companion PR to https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/247. Supports the move of public headers from tf-psa-crypto/drivers/builtin/include/mbedtls to tf-psa-crypto/include/mbedtls.

Contributes to https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/223

## PR checklist

Please add the numbers (or links) of the associated pull requests for consuming branches. You can omit branches where this pull request is not needed.

- [ ] **TF-PSA-Crypto PR** provided:  https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/247
- [ ] **development PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10122 
- [ ] **3.6 PR** not required because: 4.0/1.0 change only
