### PR TITLE
remove compat-2.x.h

### DIFF
--- a/scripts/check_names.py
+++ b/scripts/check_names.py
@@ -223,7 +223,7 @@ class CodeParser():
 
         # Globally excluded filenames.
         # Note that "*" can match directory separators in exclude lists.
-        self.excluded_files = ["*/bn_mul", "*/compat-2.x.h"]
+        self.excluded_files = ["*/bn_mul"]
 
     def _parse(self, all_macros, enum_consts, identifiers,
                excluded_identifiers, mbed_psa_words, symbols):


### PR DESCRIPTION
## Description

Remove include/mbedtls/compat-2.x.h and its reference in check_names.py.

## PR checklist

- [ ] **TF-PSA-Crypto PR** not required because: No changes
- [ ] **development PR** provided: #here
- [ ] **3.6 PR** not required because: No backports
