### PR TITLE
Fix config.py --help when the current directory contains a percent character

### DIFF
--- a/scripts/mbedtls_framework/config_common.py
+++ b/scripts/mbedtls_framework/config_common.py
@@ -416,7 +416,7 @@ class ConfigTool(metaclass=ABCMeta):
         self.parser.add_argument(
             '--file', '-f',
             help="""File to read (and modify if requested). Default: {}.
-                 """.format(default_file_path))
+                 """.format(str(default_file_path).replace('%', '%%')))
         self.parser.add_argument(
             '--force', '-o',
             action='store_true',


### PR DESCRIPTION
Fix `config.py --help` raising an exception (or otherwise misbehaving, in rare cases) when the current working directory contains a percent character. This was due to a percent escape bug.

To check for similar issues, I used the following code, which searches in all Python files for `help="...".format` or `help="..."%` or `help="...%..."`, allowing for different quote characters.
```
git ls-files --recurse-submodules '*.py' | xargs perl -000 -ne 'while (/(help=("""|"(?!")|\x27\x27\x27|\x27(?!\x27))(.*?)\2\s*(\.format|%)?)/sg) { printf "%s:%d:%s\n\n", $ARGV, $., $1 if defined $4 or $2 =~ /%/ } }continue{ close ARGV if eof'
```

## PR checklist

- [x] **TF-PSA-Crypto PR** not required because: no problem found in crypto
- [ ] **development PR** TODO (but can be done independently)
- [x] **3.6 PR** provided
