### PR TITLE
Check union initialization in test drivers

### DIFF
--- a/tests/include/test/drivers/test_driver_common.h
+++ b/tests/include/test/drivers/test_driver_common.h
@@ -8,10 +8,21 @@
 
 #include "mbedtls/build_info.h"
 
+/* Use the same formatting for error code definitions as the standard
+ * error values, which must have a specific sequence of tokens for
+ * interoperability between implementations of different parts of PSA.
+ * This means no space between the cast and the - operator.
+ * This contradicts our code style, so we temporarily disable style checking.
+ *
+ * *INDENT-OFF*
+ */
+
 /** Error code that test drivers return when they detect that an input
  * parameter was not initialized properly. This normally indicates a
  * bug in the core.
  */
 #define PSA_ERROR_TEST_DETECTED_BAD_INITIALIZATION ((psa_status_t)-0x0201)
+
+/* *INDENT-ON* */
 
 #endif /* test_driver_common.h */

--- a/tests/include/test/drivers/test_driver_common.h
+++ b/tests/include/test/drivers/test_driver_common.h
@@ -8,4 +8,10 @@
 
 #include "mbedtls/build_info.h"
 
+/** Error code that test drivers return when they detect that an input
+ * parameter was not initialized properly. This normally indicates a
+ * bug in the core.
+ */
+#define PSA_ERROR_TEST_DETECTED_BAD_INITIALIZATION ((psa_status_t)-0x0201)
+
 #endif /* test_driver_common.h */

--- a/tests/src/drivers/test_driver_aead.c
+++ b/tests/src/drivers/test_driver_aead.c
@@ -149,6 +149,9 @@ psa_status_t mbedtls_test_transparent_aead_encrypt_setup(
     if (mbedtls_test_driver_aead_hooks.forced_status != PSA_SUCCESS) {
         mbedtls_test_driver_aead_hooks.driver_status =
             mbedtls_test_driver_aead_hooks.forced_status;
+    } else if (!MBEDTLS_TEST_OBJECT_IS_ALL_ZERO(operation)) {
+        mbedtls_test_driver_aead_hooks.driver_status =
+            PSA_ERROR_TEST_DETECTED_BAD_INITIALIZATION;
     } else {
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1) && \
         defined(LIBTESTDRIVER1_MBEDTLS_PSA_BUILTIN_AEAD)
@@ -186,6 +189,9 @@ psa_status_t mbedtls_test_transparent_aead_decrypt_setup(
     if (mbedtls_test_driver_aead_hooks.forced_status != PSA_SUCCESS) {
         mbedtls_test_driver_aead_hooks.driver_status =
             mbedtls_test_driver_aead_hooks.forced_status;
+    } else if (!MBEDTLS_TEST_OBJECT_IS_ALL_ZERO(operation)) {
+        mbedtls_test_driver_aead_hooks.driver_status =
+            PSA_ERROR_TEST_DETECTED_BAD_INITIALIZATION;
     } else {
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1) && \
         defined(LIBTESTDRIVER1_MBEDTLS_PSA_BUILTIN_AEAD)

--- a/tests/src/drivers/test_driver_cipher.c
+++ b/tests/src/drivers/test_driver_cipher.c
@@ -139,14 +139,12 @@ psa_status_t mbedtls_test_transparent_cipher_encrypt_setup(
 {
     mbedtls_test_driver_cipher_hooks.hits++;
 
-    /* Wiping the entire struct here, instead of member-by-member. This is
-     * useful for the test suite, since it gives a chance of catching memory
-     * corruption errors should the core not have allocated (enough) memory for
-     * our context struct. */
-    memset(operation, 0, sizeof(*operation));
-
     if (mbedtls_test_driver_cipher_hooks.forced_status != PSA_SUCCESS) {
         return mbedtls_test_driver_cipher_hooks.forced_status;
+    }
+
+    if (!MBEDTLS_TEST_OBJECT_IS_ALL_ZERO(operation)) {
+        return PSA_ERROR_TEST_DETECTED_BAD_INITIALIZATION;
     }
 
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1) && \
@@ -173,6 +171,10 @@ psa_status_t mbedtls_test_transparent_cipher_decrypt_setup(
 
     if (mbedtls_test_driver_cipher_hooks.forced_status != PSA_SUCCESS) {
         return mbedtls_test_driver_cipher_hooks.forced_status;
+    }
+
+    if (!MBEDTLS_TEST_OBJECT_IS_ALL_ZERO(operation)) {
+        return PSA_ERROR_TEST_DETECTED_BAD_INITIALIZATION;
     }
 
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1) && \

--- a/tests/src/drivers/test_driver_mac.c
+++ b/tests/src/drivers/test_driver_mac.c
@@ -83,6 +83,9 @@ psa_status_t mbedtls_test_transparent_mac_sign_setup(
     if (mbedtls_test_driver_mac_hooks.forced_status != PSA_SUCCESS) {
         mbedtls_test_driver_mac_hooks.driver_status =
             mbedtls_test_driver_mac_hooks.forced_status;
+    } else if (!MBEDTLS_TEST_OBJECT_IS_ALL_ZERO(operation)) {
+        mbedtls_test_driver_mac_hooks.driver_status =
+            PSA_ERROR_TEST_DETECTED_BAD_INITIALIZATION;
     } else {
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1) && \
         defined(LIBTESTDRIVER1_MBEDTLS_PSA_BUILTIN_MAC)
@@ -120,6 +123,9 @@ psa_status_t mbedtls_test_transparent_mac_verify_setup(
     if (mbedtls_test_driver_mac_hooks.forced_status != PSA_SUCCESS) {
         mbedtls_test_driver_mac_hooks.driver_status =
             mbedtls_test_driver_mac_hooks.forced_status;
+    } else if (!MBEDTLS_TEST_OBJECT_IS_ALL_ZERO(operation)) {
+        mbedtls_test_driver_mac_hooks.driver_status =
+            PSA_ERROR_TEST_DETECTED_BAD_INITIALIZATION;
     } else {
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1) && \
         defined(LIBTESTDRIVER1_MBEDTLS_PSA_BUILTIN_MAC)
@@ -309,6 +315,9 @@ psa_status_t mbedtls_test_opaque_mac_sign_setup(
     if (mbedtls_test_driver_mac_hooks.forced_status != PSA_SUCCESS) {
         mbedtls_test_driver_mac_hooks.driver_status =
             mbedtls_test_driver_mac_hooks.forced_status;
+    } else if (!MBEDTLS_TEST_OBJECT_IS_ALL_ZERO(operation)) {
+        mbedtls_test_driver_mac_hooks.driver_status =
+            PSA_ERROR_TEST_DETECTED_BAD_INITIALIZATION;
     } else {
         (void) operation;
         (void) attributes;
@@ -333,6 +342,9 @@ psa_status_t mbedtls_test_opaque_mac_verify_setup(
     if (mbedtls_test_driver_mac_hooks.forced_status != PSA_SUCCESS) {
         mbedtls_test_driver_mac_hooks.driver_status =
             mbedtls_test_driver_mac_hooks.forced_status;
+    } else if (!MBEDTLS_TEST_OBJECT_IS_ALL_ZERO(operation)) {
+        mbedtls_test_driver_mac_hooks.driver_status =
+            PSA_ERROR_TEST_DETECTED_BAD_INITIALIZATION;
     } else {
         (void) operation;
         (void) attributes;

--- a/tests/src/drivers/test_driver_pake.c
+++ b/tests/src/drivers/test_driver_pake.c
@@ -35,6 +35,9 @@ psa_status_t mbedtls_test_transparent_pake_setup(
     if (mbedtls_test_driver_pake_hooks.forced_setup_status != PSA_SUCCESS) {
         mbedtls_test_driver_pake_hooks.driver_status =
             mbedtls_test_driver_pake_hooks.forced_setup_status;
+    } else if (!MBEDTLS_TEST_OBJECT_IS_ALL_ZERO(operation)) {
+        mbedtls_test_driver_pake_hooks.driver_status =
+            PSA_ERROR_TEST_DETECTED_BAD_INITIALIZATION;
     } else {
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1) && \
         defined(LIBTESTDRIVER1_MBEDTLS_PSA_BUILTIN_PAKE)


### PR DESCRIPTION
Improved testing for https://github.com/Mbed-TLS/mbedtls/issues/9814 and https://github.com/Mbed-TLS/mbedtls/issues/9975:

* In test drivers, check that the context is zero on entry to setup. This validates the fix for https://github.com/Mbed-TLS/mbedtls/issues/9975, and also validates that the frontend is robust against https://github.com/Mbed-TLS/mbedtls/issues/9814.

Needs preceding PR: this must not be merged until the bug fix in https://github.com/Mbed-TLS/mbedtls/pull/10168 and https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/295 is merged, since this adds new validation in auxiliary functions that the unit tests already call.

## PR checklist

- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/296
- [x] **development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10178
- [x] **3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10179
