### PR TITLE
Fix GCC 15 warning 'Wunterminated-string-initialization'

### DIFF
--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -184,7 +184,8 @@ static int exercise_cipher_key(mbedtls_svc_key_id_t key,
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_type_t key_type;
     const unsigned char plaintext[16] = "Hello, world...";
-    unsigned char ciphertext[32] = "(wabblewebblewibblewobblewubble)";
+    /* We need to tell the compiler that we meant to leave out the null character. */
+    unsigned char ciphertext[32] __attribute__ ((nonstring)) = "(wabblewebblewibblewobblewubble)";
     size_t ciphertext_length = sizeof(ciphertext);
     unsigned char decrypted[sizeof(ciphertext)];
     size_t part_length;

--- a/tests/src/psa_exercise_key.c
+++ b/tests/src/psa_exercise_key.c
@@ -185,7 +185,8 @@ static int exercise_cipher_key(mbedtls_svc_key_id_t key,
     psa_key_type_t key_type;
     const unsigned char plaintext[16] = "Hello, world...";
     /* We need to tell the compiler that we meant to leave out the null character. */
-    unsigned char ciphertext[32] __attribute__ ((nonstring)) = "(wabblewebblewibblewobblewubble)";
+    unsigned char ciphertext[32] MBEDTLS_ATTRIBUTE_UNTERMINATED_STRING =
+        "(wabblewebblewibblewobblewubble)";
     size_t ciphertext_length = sizeof(ciphertext);
     unsigned char decrypted[sizeof(ciphertext)];
     size_t part_length;


### PR DESCRIPTION
framework part of and resolves https://github.com/Mbed-TLS/mbedtls/issues/9944
Depends on https://github.com/Mbed-TLS/mbedtls/pull/10215, https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/313 & https://github.com/Mbed-TLS/mbedtls/pull/10216

Merge order:
Merge the `TF-PSA-Crypto` PR https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/313
Update the `tf-psa-crypto` submodule pointer on the `mbedtls` development PR (https://github.com/Mbed-TLS/mbedtls/pull/10216) to the merge commit of the `TF-PSA-Crypto` PR
Merge the `mbedtls` development PR

(Independently) Merge the 3.6 `mbedtls` PR https://github.com/Mbed-TLS/mbedtls/pull/10215

Then replay or re-trigger the CI, which will pick up the required changes in `mbedtls` development and `mbedtls` 3.6 and then should be green.

## PR checklist

- [ ] **TF-PSA-Crypto PR** provided: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/313
- [ ] **development PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10216
- [ ] **3.6 PR** provided: https://github.com/Mbed-TLS/mbedtls/pull/10215