### PR TITLE
assemble_changelog.py: Clean up datetime.fromtimestamp timezone handling

### DIFF
--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -350,13 +350,13 @@ class EntryFileSortKey:
         text = subprocess.check_output(['git', 'show', '-s',
                                         '--format=%ct',
                                         commit_id])
-        return datetime.datetime.utcfromtimestamp(int(text))
+        return datetime.datetime.fromtimestamp(int(text), datetime.timezone.utc)
 
     @staticmethod
     def file_timestamp(filename):
         """Return the modification timestamp of the given file."""
         mtime = os.stat(filename).st_mtime
-        return datetime.datetime.fromtimestamp(mtime)
+        return datetime.datetime.fromtimestamp(mtime, datetime.timezone.utc)
 
     def __init__(self, filename):
         """Determine position of the file in the changelog entry order.


### PR DESCRIPTION
Get rid of harmless warnings when you run `assemble_changelog.py` with Python ≥3.12. We're using a deprecated function [`datetime.datetime.utcfromtimestamp`](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp), but we happen to be using it safely, and at the time of posting the function hasn't been removed yet.

This is the only script where we use `datetime.datetime.utcfromtimestamp`.

## PR checklist

- [x] **TF-PSA-Crypto PR** not required because: only refactoring
- [x] **development PR** not required because: only refactoring
- [x] **3.6 PR** not required because: only refactoring
