### PR TITLE
Use a null pointer for empty data

### DIFF
--- a/tests/src/helpers.c
+++ b/tests/src/helpers.c
@@ -632,19 +632,6 @@ void mbedtls_test_hexify(unsigned char *obuf,
     }
 }
 
-unsigned char *mbedtls_test_zero_alloc(size_t len)
-{
-    void *p;
-    size_t actual_len = (len != 0) ? len : 1;
-
-    p = mbedtls_calloc(1, actual_len);
-    TEST_HELPER_ASSERT(p != NULL);
-
-    memset(p, 0x00, actual_len);
-
-    return p;
-}
-
 unsigned char *mbedtls_test_unhexify_alloc(const char *ibuf, size_t *olen)
 {
     unsigned char *obuf;
@@ -653,7 +640,11 @@ unsigned char *mbedtls_test_unhexify_alloc(const char *ibuf, size_t *olen)
     *olen = strlen(ibuf) / 2;
 
     if (*olen == 0) {
-        return mbedtls_test_zero_alloc(*olen);
+        /* Any pointer should work for an empty buffer. Use NULL, to ensure
+         * that the library doesn't spuriously check for NULL. In Asan builds,
+         * we also validate that the library doesn't call functions such as
+         * memset() and memcpy() which reject NULL even for a size of 0. */
+        return NULL;
     }
 
     obuf = mbedtls_calloc(1, *olen);


### PR DESCRIPTION
In binary arguments to test functions, don't allocate an extra byte when a binary input is empty. This could hide bugs where the library tries to access one byte in an empty buffer.

Needs preceding PR: 3.6 and crypto to stop using `mbedtls_test_zero_alloc()` first.

## PR checklist

- [x] **changelog** not required because: test only
- [ ] **development PR** TODO (or not required?)
- [ ] **TF-PSA-Crypto PR** TODO
- [x] **framework PR** here
- [x] **3.6 PR** https://github.com/Mbed-TLS/mbedtls/pull/10257
- **tests**  provided
