### PR TITLE
test_psa_compliance: Link only with tfpsacrypto library

### DIFF
--- a/scripts/test_psa_compliance.py
+++ b/scripts/test_psa_compliance.py
@@ -44,11 +44,9 @@ def main(library_build_dir: str):
     subprocess.check_call(['cmake', '--build', library_build_dir, '--target', 'install'])
 
     if build_tree.is_mbedtls_3_6():
-        libraries_to_link = [str(install_dir.joinpath("lib/libmbedcrypto.a"))]
+        crypto_library_path = install_dir.joinpath("lib/libmbedcrypto.a")
     else:
-        libraries_to_link = [str(install_dir.joinpath("lib/" + lib))
-                             for lib in ["libtfpsacrypto.a", "libbuiltin.a",
-                                         "libp256m.a", "libeverest.a"]]
+        crypto_library_path = install_dir.joinpath("lib/libtfpsacrypto.a")
 
     psa_arch_tests_dir = 'psa-arch-tests'
     os.makedirs(psa_arch_tests_dir, exist_ok=True)
@@ -75,7 +73,7 @@ def main(library_build_dir: str):
                      '-DTARGET=tgt_dev_apis_stdc',
                      '-DTOOLCHAIN=HOST_GCC',
                      '-DSUITE=CRYPTO',
-                     '-DPSA_CRYPTO_LIB_FILENAME={}'.format(';'.join(libraries_to_link)),
+                     '-DPSA_CRYPTO_LIB_FILENAME={}'.format(str(crypto_library_path)),
                      '-DPSA_INCLUDE_PATHS=' + str(install_dir.joinpath("include"))
         ])
 


### PR DESCRIPTION
## Description
Following the change to only one crypto library instead of a core one and driver libraries, link the PSA crypto compliance test suites only to the tfpsacrypto library.
Next step in the resolution of https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/300 after the merge of https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/332.

## PR checklist
- [x] **TF-PSA-Crypto PR** provided Mbed-TLS/TF-PSA-Crypto#332 (prerequisite to this PR)
- [ ] **development PR** provided # TODO (just related PR, no direct dependency between them)
- [x] **3.6 PR** not required because: no impact on 3.6