### PR TITLE
Revised entropy callback

### DIFF
--- a/tests/include/test/fake_external_rng_for_test.h
+++ b/tests/include/test/fake_external_rng_for_test.h
@@ -37,7 +37,7 @@ void mbedtls_test_enable_insecure_external_rng(void);
 void mbedtls_test_disable_insecure_external_rng(void);
 #endif /* MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */
 
-#if defined(MBEDTLS_PLATFORM_GET_ENTROPY_ALT)
+#if defined(MBEDTLS_PLATFORM_GET_ENTROPY_ALT) || defined(MBEDTLS_PSA_DRIVER_GET_ENTROPY)
 
 #include <mbedtls/platform.h>
 
@@ -73,6 +73,6 @@ void mbedtls_test_platform_get_entropy_set_entropy_content(size_t val);
 /* Return the number of times mbedtls_platform_get_entropy() was called. */
 size_t mbedtls_test_platform_get_entropy_get_call_count(void);
 
-#endif /* MBEDTLS_PLATFORM_GET_ENTROPY_ALT */
+#endif /* MBEDTLS_PLATFORM_GET_ENTROPY_ALT || MBEDTLS_PSA_DRIVER_GET_ENTROPY */
 
 #endif /* FAKE_EXTERNAL_RNG_FOR_TEST_H */

--- a/tests/src/fake_external_rng_for_test.c
+++ b/tests/src/fake_external_rng_for_test.c
@@ -90,7 +90,7 @@ size_t mbedtls_test_platform_get_entropy_get_call_count()
 }
 
 static int fake_get_entropy(unsigned char *output, size_t output_size,
-                            size_t *entropy_content)
+                            size_t *estimate_bits)
 {
     platform_get_entropy_call_count++;
 
@@ -110,11 +110,11 @@ static int fake_get_entropy(unsigned char *output, size_t output_size,
 
     mbedtls_test_rnd_std_rand(NULL, output, output_size);
 
-    if (entropy_content != NULL) {
+    if (estimate_bits != NULL) {
         if (platform_get_entropy_forced_entropy_content < SIZE_MAX) {
-            *entropy_content = platform_get_entropy_forced_entropy_content;
+            *estimate_bits = platform_get_entropy_forced_entropy_content;
         } else {
-            *entropy_content = output_size * 8;
+            *estimate_bits = output_size * 8;
         }
     }
 
@@ -146,9 +146,9 @@ int mbedtls_platform_get_entropy(unsigned char *output, size_t output_size,
 
 #if defined(MBEDTLS_PSA_DRIVER_GET_ENTROPY)
 int mbedtls_platform_get_entropy(unsigned char *output, size_t output_size,
-                                 size_t *entropy_content)
+                                 size_t *estimate_bits)
 {
-    int ret = fake_get_entropy(output, output_size, entropy_content);
+    int ret = fake_get_entropy(output, output_size, estimate_bits);
     return ret;
 }
 #endif /* MBEDTLS_PSA_DRIVER_GET_ENTROPY */

--- a/tests/src/fake_external_rng_for_test.c
+++ b/tests/src/fake_external_rng_for_test.c
@@ -146,16 +146,9 @@ int mbedtls_platform_get_entropy(unsigned char *output, size_t output_size,
 
 #if defined(MBEDTLS_PSA_DRIVER_GET_ENTROPY)
 int mbedtls_platform_get_entropy(unsigned char *output, size_t output_size,
-                                 size_t *output_len, size_t *entropy_content)
+                                 size_t *entropy_content)
 {
     int ret = fake_get_entropy(output, output_size, entropy_content);
-    if (ret == 0) {
-        if (platform_get_entropy_forced_output_len == SIZE_MAX) {
-            *output_len = output_size;
-        } else {
-            *output_len = platform_get_entropy_forced_output_len;
-        }
-    }
     return ret;
 }
 #endif /* MBEDTLS_PSA_DRIVER_GET_ENTROPY */

--- a/tests/src/fake_external_rng_for_test.c
+++ b/tests/src/fake_external_rng_for_test.c
@@ -15,6 +15,10 @@
 
 #include <test/fake_external_rng_for_test.h>
 
+#if defined(MBEDTLS_PSA_DRIVER_GET_ENTROPY)
+#include <psa/crypto_driver_random.h>
+#endif
+
 #if defined(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
 
 #include <test/random.h>
@@ -145,9 +149,15 @@ int mbedtls_platform_get_entropy(unsigned char *output, size_t output_size,
 #endif /* MBEDTLS_PLATFORM_GET_ENTROPY_ALT */
 
 #if defined(MBEDTLS_PSA_DRIVER_GET_ENTROPY)
-int mbedtls_platform_get_entropy(unsigned char *output, size_t output_size,
-                                 size_t *estimate_bits)
+int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags,
+                                 size_t *estimate_bits,
+                                 unsigned char *output, size_t output_size)
 {
+    /* We don't implement any flags yet. */
+    if (flags != 0) {
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
+
     int ret = fake_get_entropy(output, output_size, estimate_bits);
     return ret;
 }

--- a/tests/src/fake_external_rng_for_test.c
+++ b/tests/src/fake_external_rng_for_test.c
@@ -51,7 +51,7 @@ psa_status_t mbedtls_psa_external_get_random(
 
 #endif /* MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */
 
-#if defined(MBEDTLS_PLATFORM_GET_ENTROPY_ALT)
+#if defined(MBEDTLS_PLATFORM_GET_ENTROPY_ALT) || defined(MBEDTLS_PSA_DRIVER_GET_ENTROPY)
 
 #include <test/random.h>
 #include <mbedtls/entropy.h>
@@ -121,7 +121,7 @@ static int fake_get_entropy(unsigned char *output, size_t output_size,
     return 0;
 }
 
-#endif /* MBEDTLS_PLATFORM_GET_ENTROPY_ALT */
+#endif /* MBEDTLS_PLATFORM_GET_ENTROPY_ALT || MBEDTLS_PSA_DRIVER_GET_ENTROPY */
 
 /* Form of the callback introduced in
  * https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/212 ,
@@ -143,3 +143,19 @@ int mbedtls_platform_get_entropy(unsigned char *output, size_t output_size,
     return ret;
 }
 #endif /* MBEDTLS_PLATFORM_GET_ENTROPY_ALT */
+
+#if defined(MBEDTLS_PSA_DRIVER_GET_ENTROPY)
+int mbedtls_platform_get_entropy(unsigned char *output, size_t output_size,
+                                 size_t *output_len, size_t *entropy_content)
+{
+    int ret = fake_get_entropy(output, output_size, entropy_content);
+    if (ret == 0) {
+        if (platform_get_entropy_forced_output_len == SIZE_MAX) {
+            *output_len = output_size;
+        } else {
+            *output_len = platform_get_entropy_forced_output_len;
+        }
+    }
+    return ret;
+}
+#endif /* MBEDTLS_PSA_DRIVER_GET_ENTROPY */


### PR DESCRIPTION
Framework part of https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/369 to support the new callback for https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/307. The old callback is still supported to help the transition.

## PR checklist

- [x] **TF-PSA-Crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/369
- [ ] **development PR** not required because: crypto only (to be confirmed)
- [x] **3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10210 (just an additional test)
