### PR TITLE
Remove support for static ECDH cipher suites

### DIFF
--- a/scripts/all-helpers.sh
+++ b/scripts/all-helpers.sh
@@ -147,7 +147,6 @@ helper_psasim_config() {
         # Disable potentially problematic features
         scripts/config.py unset MBEDTLS_X509_RSASSA_PSS_SUPPORT
         scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
-        scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
         scripts/config.py unset MBEDTLS_ECP_RESTARTABLE
         scripts/config.py unset MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
     else


### PR DESCRIPTION
## Description

Remove support for static ECDH cipher suites, contributes https://github.com/Mbed-TLS/mbedtls/issues/9201

This PR is part of a chain which needs to be merged in the following order:

1. https://github.com/Mbed-TLS/mbedtls-framework/pull/182
2. https://github.com/Mbed-TLS/mbedtls/pull/10294

## PR checklist

- [ ] **TF-PSA-Crypto PR** not required because: No changes
- [ ] **development PR** provided #HERE
- [ ] **3.6 PR** not required because: No backports