### PR TITLE
Allow the `tf_psa` prefix for functions

### DIFF
--- a/scripts/check_names.py
+++ b/scripts/check_names.py
@@ -56,7 +56,7 @@ from mbedtls_framework import build_tree
 PUBLIC_MACRO_PATTERN = r"^(MBEDTLS|PSA|TF_PSA)_[0-9A-Z_]*[0-9A-Z]$"
 INTERNAL_MACRO_PATTERN = r"^[0-9A-Za-z_]*[0-9A-Z]$"
 CONSTANTS_PATTERN = PUBLIC_MACRO_PATTERN
-IDENTIFIER_PATTERN = r"^(mbedtls|psa)_[0-9a-z_]*[0-9a-z]$"
+IDENTIFIER_PATTERN = r"^(mbedtls|psa|tf_psa)_[0-9a-z_]*[0-9a-z]$"
 
 class Match(): # pylint: disable=too-few-public-methods
     """


### PR DESCRIPTION
Allow functions to have the prefix `tf_psa` in check_names.py. This is needed for new functions added in TF-PSA-Crypto.

## PR checklist

Please add the numbers (or links) of the associated pull requests for consuming branches. You can omit branches where this pull request is not needed.

- [x] **TF-PSA-Crypto PR** not required because: This change stands on its own as a change in allowed-name policy
- [x] **development PR** not required because: Ditto the above
- [x] **3.6 PR** not required because: Ditto the above
