### PR TITLE
New threading interface: prototype (framework)

### DIFF
--- a/tests/include/test/threading_helpers.h
+++ b/tests/include/test/threading_helpers.h
@@ -25,6 +25,12 @@
 
 #define MBEDTLS_ERR_THREADING_THREAD_ERROR                 -0x001F
 
+#if defined(MBEDTLS_THREADING_C11)
+#include <threads.h>
+typedef int mbedtls_test_thread_return_t;
+#define MBEDTLS_TEST_THREAD_RETURN_0 0
+#endif /* MBEDTLS_THREADING_C11 */
+
 #if defined(MBEDTLS_THREADING_PTHREAD)
 #include <pthread.h>
 /** Type returned by ::mbedtls_test_thread_function_t */
@@ -42,9 +48,11 @@ typedef void *mbedtls_test_thread_return_t;
 
 typedef struct mbedtls_test_thread_t {
 
-#if defined(MBEDTLS_THREADING_PTHREAD)
+#if defined(MBEDTLS_THREADING_C11)
+    thrd_t MBEDTLS_PRIVATE(thread);
+#elif defined(MBEDTLS_THREADING_PTHREAD)
     pthread_t MBEDTLS_PRIVATE(thread);
-#else /* MBEDTLS_THREADING_PTHREAD */
+#else /* MBEDTLS_THREADING_ALT */
     /* Make sure this struct is always non-empty */
     unsigned dummy;
 #endif

--- a/tests/include/test/threading_helpers.h
+++ b/tests/include/test/threading_helpers.h
@@ -33,26 +33,6 @@
 /* You should define the mbedtls_test_thread_t type in your header */
 #include "threading_alt.h"
 
-/**
- * \brief                   Set your alternate threading implementation
- *                          function pointers for test threads. If used, this
- *                          function must be called once in the main thread
- *                          before any other MbedTLS function is called.
- *
- * \note                    These functions are part of the testing API only and
- *                          thus not considered part of the public API of
- *                          MbedTLS and thus may change without notice.
- *
- * \param thread_create     The thread create function implementation.
- * \param thread_join       The thread join function implementation.
-
- */
-void mbedtls_test_thread_set_alt(int (*thread_create)(mbedtls_test_thread_t *thread,
-                                                      void *(*thread_func)(
-                                                          void *),
-                                                      void *thread_data),
-                                 int (*thread_join)(mbedtls_test_thread_t *thread));
-
 #else /* MBEDTLS_THREADING_ALT*/
 
 typedef struct mbedtls_test_thread_t {

--- a/tests/include/test/threading_helpers.h
+++ b/tests/include/test/threading_helpers.h
@@ -27,6 +27,11 @@
 
 #if defined(MBEDTLS_THREADING_PTHREAD)
 #include <pthread.h>
+/** Type returned by ::mbedtls_test_thread_function_t */
+typedef void *mbedtls_test_thread_return_t;
+/** A value of type ::mbedtls_test_thread_return_t, to return from
+ * ::mbedtls_test_thread_function_t. */
+#define MBEDTLS_TEST_THREAD_RETURN_0 NULL
 #endif /* MBEDTLS_THREADING_PTHREAD */
 
 #if defined(MBEDTLS_THREADING_ALT)
@@ -48,6 +53,10 @@ typedef struct mbedtls_test_thread_t {
 
 #endif /* MBEDTLS_THREADING_ALT*/
 
+/** The type of thread functions.
+ */
+typedef mbedtls_test_thread_return_t (mbedtls_test_thread_function_t)(void *);
+
 /**
  * \brief                   The function pointers for thread create and thread
  *                          join.
@@ -60,7 +69,8 @@ typedef struct mbedtls_test_thread_t {
  *                          the result will be undefined.
  */
 extern int (*mbedtls_test_thread_create)(mbedtls_test_thread_t *thread,
-                                         void *(*thread_func)(void *), void *thread_data);
+                                         mbedtls_test_thread_function_t thread_func,
+                                         void *thread_data);
 extern int (*mbedtls_test_thread_join)(mbedtls_test_thread_t *thread);
 
 #if defined(MBEDTLS_TEST_HOOKS_FOR_MUTEX_USAGE) || \

--- a/tests/include/test/threading_helpers.h
+++ b/tests/include/test/threading_helpers.h
@@ -83,7 +83,8 @@ extern int (*mbedtls_test_thread_create)(mbedtls_test_thread_t *thread,
                                          void *(*thread_func)(void *), void *thread_data);
 extern int (*mbedtls_test_thread_join)(mbedtls_test_thread_t *thread);
 
-#if defined(MBEDTLS_THREADING_PTHREAD) && defined(MBEDTLS_TEST_HOOKS)
+#if defined(MBEDTLS_TEST_HOOKS_FOR_MUTEX_USAGE) || \
+    (defined(MBEDTLS_THREADING_PTHREAD) && defined(MBEDTLS_TEST_HOOKS))
 #define MBEDTLS_TEST_MUTEX_USAGE
 #endif
 

--- a/tests/src/threading_helpers.c
+++ b/tests/src/threading_helpers.c
@@ -19,8 +19,9 @@
 
 #if defined(MBEDTLS_THREADING_PTHREAD)
 
-static int threading_thread_create_pthread(mbedtls_test_thread_t *thread, void *(*thread_func)(
-                                               void *), void *thread_data)
+static int threading_thread_create_pthread(mbedtls_test_thread_t *thread,
+                                           mbedtls_test_thread_function_t thread_func,
+                                           void *thread_data)
 {
     if (thread == NULL || thread_func == NULL) {
         return MBEDTLS_ERR_THREADING_BAD_INPUT_DATA;
@@ -46,7 +47,8 @@ static int threading_thread_join_pthread(mbedtls_test_thread_t *thread)
     return 0;
 }
 
-int (*mbedtls_test_thread_create)(mbedtls_test_thread_t *thread, void *(*thread_func)(void *),
+int (*mbedtls_test_thread_create)(mbedtls_test_thread_t *thread,
+                                  mbedtls_test_thread_function_t thread_func,
                                   void *thread_data) = threading_thread_create_pthread;
 int (*mbedtls_test_thread_join)(mbedtls_test_thread_t *thread) = threading_thread_join_pthread;
 
@@ -72,7 +74,8 @@ static int threading_thread_join_fail(mbedtls_test_thread_t *thread)
     return MBEDTLS_ERR_THREADING_BAD_INPUT_DATA;
 }
 
-int (*mbedtls_test_thread_create)(mbedtls_test_thread_t *thread, void *(*thread_func)(void *),
+int (*mbedtls_test_thread_create)(mbedtls_test_thread_t *thread,
+                                  mbedtls_test_thread_function_t thread_func,
                                   void *thread_data) = threading_thread_create_fail;
 int (*mbedtls_test_thread_join)(mbedtls_test_thread_t *thread) = threading_thread_join_fail;
 

--- a/tests/src/threading_helpers.c
+++ b/tests/src/threading_helpers.c
@@ -436,7 +436,7 @@ void mbedtls_test_mutex_usage_init(void)
 #endif /* MBEDTLS_TEST_HOOKS_FOR_MUTEX_USAGE */
 
 #if defined(MBEDTLS_TEST_HOOKS_FOR_MUTEX_USAGE)
-    mbedtls_platform_mutex_init(&mbedtls_test_mutex_mutex);
+    (void) mbedtls_platform_mutex_setup(&mbedtls_test_mutex_mutex);
 #else
     mutex_functions.init(&mbedtls_test_mutex_mutex);
 #endif
@@ -482,7 +482,7 @@ void mbedtls_test_mutex_usage_end(void)
 #endif /* MBEDTLS_TEST_HOOKS_FOR_MUTEX_USAGE */
 
 #if defined(MBEDTLS_TEST_HOOKS_FOR_MUTEX_USAGE)
-    mbedtls_platform_mutex_free(&mbedtls_test_mutex_mutex);
+    mbedtls_platform_mutex_destroy(&mbedtls_test_mutex_mutex);
 #else
     mutex_functions.free(&mbedtls_test_mutex_mutex);
 #endif


### PR DESCRIPTION
Framework support for https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/415. Contributes to https://github.com/Mbed-TLS/mbedtls/issues/8455.

The changes to the framework are pretty messy. I tried to change the framework incrementally while mostly preserving compatibility at each step, but it didn't really work. I think it would be better to essentially write a new version of the threading helpers.

For 3.6, I think we should evolve at least the thread create/join functions and maybe parts of the mutex usage framework to be closer to the TF-PSA-Crypto state. That is an internal matter that can be cleaned up after the 1.0/4.0 release.

## PR checklist

- [x] **framework PR** here
- [ ] **TF-PSA-Crypto PR** https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/415
- [ ] **mbedtls development PR** TODO?
- [ ] **mbedtls 3.6 PR** not required because: no changes in 3.6
- **tests**  provided
