### PR TITLE
Prepare for the removal of legacy ECC crypto options

### DIFF
--- a/scripts/all-helpers.sh
+++ b/scripts/all-helpers.sh
@@ -149,6 +149,8 @@ helper_psasim_config() {
         scripts/config.py unset MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
         scripts/config.py unset MBEDTLS_ECP_RESTARTABLE
         scripts/config.py unset MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
+        scripts/config.py unset MBEDTLS_PK_PARSE_EC_EXTENDED
+        scripts/config.py unset MBEDTLS_PK_PARSE_EC_COMPRESSED
 
         scripts/config.py unset-all MBEDTLS_SHA256_USE_.*_CRYPTO_
         scripts/config.py unset-all MBEDTLS_SHA512_USE_.*_CRYPTO_


### PR DESCRIPTION
## Description
Preparatory work for the removal of legacy ECC crypto options addressing issue https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/364.

## PR checklist

Please add the numbers (or links) of the associated pull requests for consuming branches. You can omit branches where this pull request is not needed.

- [ ] **TF-PSA-Crypto PR** provided # | not required because: 
- [ ] **development PR** provided # | not required because: 
- [ ] **3.6 PR** not required because: should not have any impact on 3.6