### PR TITLE
Add private headers to check_names.py for the mbedtls main repository

### DIFF
--- a/scripts/check_names.py
+++ b/scripts/check_names.py
@@ -903,6 +903,7 @@ class MBEDTLSCodeParser(CodeParser):
             all_macros = {"public": [], "internal": [], "private":[]}
             all_macros["public"] = self.parse_macros([
                 "include/mbedtls/*.h",
+                "include/mbedtls/private/*.h",
             ])
             all_macros["internal"] = self.parse_macros([
                 "library/*.h",
@@ -913,15 +914,18 @@ class MBEDTLSCodeParser(CodeParser):
             ])
             enum_consts = self.parse_enum_consts([
                 "include/mbedtls/*.h",
+                "include/mbedtls/private/*.h",
                 "library/*.h",
                 "library/*.c",
             ])
             identifiers, excluded_identifiers = self.parse_identifiers([
                 "include/mbedtls/*.h",
+                "include/mbedtls/private/*.h",
                 "library/*.h",
             ])
             mbed_psa_words = self.parse_mbed_psa_words([
                 "include/mbedtls/*.h",
+                "include/mbedtls/private/*.h",
                 "library/*.h",
                 "library/*.c",
             ])


### PR DESCRIPTION
## Description
This PR adds the private headers to the check_names.py script for the mbedtls main repository.

## PR checklist

- [X] **TF-PSA-Crypto PR** not required because: already done 
- [X] **development PR** provided: Mbed-TLS/mbedtls#10224
- [X] **3.6 PR** not required because: no backport required