### PR TITLE
Cleanup following the simplification of entropy and RNG options

### DIFF
--- a/scripts/all-helpers.sh
+++ b/scripts/all-helpers.sh
@@ -139,6 +139,8 @@ helper_psasim_config() {
         scripts/config.py full
         scripts/config.py unset MBEDTLS_PSA_CRYPTO_C
         scripts/config.py unset MBEDTLS_PSA_CRYPTO_STORAGE_C
+        scripts/config.py unset MBEDTLS_ENTROPY_NV_SEED
+        scripts/config.py unset MBEDTLS_PLATFORM_NV_SEED_ALT
         if in_mbedtls_repo && in_3_6_branch; then
             # Dynamic secure element support is a deprecated feature and it is not
             # available when CRYPTO_C and PSA_CRYPTO_STORAGE_C are disabled.

--- a/tests/include/test/fake_external_rng_for_test.h
+++ b/tests/include/test/fake_external_rng_for_test.h
@@ -37,7 +37,7 @@ void mbedtls_test_enable_insecure_external_rng(void);
 void mbedtls_test_disable_insecure_external_rng(void);
 #endif /* MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */
 
-#if defined(MBEDTLS_PLATFORM_GET_ENTROPY_ALT) || defined(MBEDTLS_PSA_DRIVER_GET_ENTROPY)
+#if defined(MBEDTLS_PSA_DRIVER_GET_ENTROPY)
 
 #include <mbedtls/platform.h>
 
@@ -73,6 +73,6 @@ void mbedtls_test_platform_get_entropy_set_entropy_content(size_t val);
 /* Return the number of times mbedtls_platform_get_entropy() was called. */
 size_t mbedtls_test_platform_get_entropy_get_call_count(void);
 
-#endif /* MBEDTLS_PLATFORM_GET_ENTROPY_ALT || MBEDTLS_PSA_DRIVER_GET_ENTROPY */
+#endif /* MBEDTLS_PSA_DRIVER_GET_ENTROPY */
 
 #endif /* FAKE_EXTERNAL_RNG_FOR_TEST_H */

--- a/tests/src/fake_external_rng_for_test.c
+++ b/tests/src/fake_external_rng_for_test.c
@@ -55,7 +55,7 @@ psa_status_t mbedtls_psa_external_get_random(
 
 #endif /* MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG */
 
-#if defined(MBEDTLS_PLATFORM_GET_ENTROPY_ALT) || defined(MBEDTLS_PSA_DRIVER_GET_ENTROPY)
+#if defined(MBEDTLS_PSA_DRIVER_GET_ENTROPY)
 
 #include <test/random.h>
 
@@ -130,7 +130,7 @@ static int fake_get_entropy(unsigned char *output, size_t output_size,
     return 0;
 }
 
-#endif /* MBEDTLS_PLATFORM_GET_ENTROPY_ALT || MBEDTLS_PSA_DRIVER_GET_ENTROPY */
+#endif /* MBEDTLS_PSA_DRIVER_GET_ENTROPY */
 
 #if defined(MBEDTLS_PSA_DRIVER_GET_ENTROPY)
 int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags,
@@ -145,18 +145,4 @@ int mbedtls_platform_get_entropy(psa_driver_get_entropy_flags_t flags,
     int ret = fake_get_entropy(output, output_size, estimate_bits);
     return ret;
 }
-#elif defined(MBEDTLS_PLATFORM_GET_ENTROPY_ALT)
-int mbedtls_platform_get_entropy(unsigned char *output, size_t output_size,
-                                 size_t *output_len, size_t *entropy_content)
-{
-    int ret = fake_get_entropy(output, output_size, entropy_content);
-    if (ret == 0) {
-        if (platform_get_entropy_forced_output_len == SIZE_MAX) {
-            *output_len = output_size;
-        } else {
-            *output_len = platform_get_entropy_forced_output_len;
-        }
-    }
-    return ret;
-}
-#endif /* MBEDTLS_PLATFORM_GET_ENTROPY_ALT */
+#endif /* MBEDTLS_PSA_DRIVER_GET_ENTROPY */


### PR DESCRIPTION
## Description
Cleanup following the simplification of entropy and RNG options
Address partially:
- https://github.com/Mbed-TLS/mbedtls/issues/10300 (removal of MBEDTLS_PLATFORM_GET_ENTROPY_ALT)

## PR checklist
- [ ] **TF-PSA-Crypto PR** provided # | not required because: 
- [ ] **development PR** provided # | not required because: 
- [ ] **3.6 PR** provided # | not required because: 