### PR TITLE
Fix generate_config_checks.py not actually generating the files

### DIFF
--- a/scripts/mbedtls_framework/config_checks_generator.py
+++ b/scripts/mbedtls_framework/config_checks_generator.py
@@ -218,9 +218,9 @@ def main(branch_data: BranchData) -> None:
                         help='output file location (default: %(default)s)')
     options = parser.parse_args()
     list_only = options.list or options.list_for_cmake
-    output_files = generate_header_files(branch_data,
-                                         options.output_directory,
-                                         list_only=list_only)
+    output_files = list(generate_header_files(branch_data,
+                                              options.output_directory,
+                                              list_only=list_only))
     if options.list_for_cmake:
         sys.stdout.write(';'.join(output_files))
     elif options.list:


### PR DESCRIPTION
Fix silly mistake in #196 that clogs up the chain of consumers.

## PR checklist

Please add the numbers (or links) of the associated pull requests for consuming branches. You can omit branches where this pull request is not needed.

- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/404
- [x] **development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10340
- [x] **3.6 PR** not required because: new featre
