### PR TITLE
Fix generate_config_checks.py not satisfying make_generated_files --check --root

### DIFF
--- a/scripts/make_generated_files.py
+++ b/scripts/make_generated_files.py
@@ -239,6 +239,10 @@ def check_generated_files(generation_scripts: List[GenerationScript], root: Path
         for file in generation_script.files:
             file = root / file
             bak_file = file.with_name(file.name + ".bak")
+            if generation_script.optional and not bak_file.exists():
+                # This file is optional and didn't exist before, so
+                # there's nothing to compare to, or clean up.
+                continue
             if not filecmp.cmp(file, bak_file):
                 ref_file = file.with_name(file.name + ".ref")
                 ref_file = root / ref_file

--- a/scripts/make_generated_files.py
+++ b/scripts/make_generated_files.py
@@ -205,6 +205,8 @@ def check_generated_files(generation_scripts: List[GenerationScript], root: Path
     for generation_script in generation_scripts:
         for file in generation_script.files:
             file = root / file
+            if not file.exists():
+                raise Exception(f"Expected generated file does not exist: {file}")
             bak_file = file.with_name(file.name + ".bak")
             if bak_file.exists():
                 bak_file.unlink()

--- a/scripts/make_generated_files.py
+++ b/scripts/make_generated_files.py
@@ -24,7 +24,7 @@ class GenerationScript:
     """
     Representation of a script generating a configuration independent file.
     """
-    # pylint: disable=too-few-public-methods
+    # pylint: disable=too-few-public-methods,too-many-arguments
     def __init__(self, script: Path, files: List[Path],
                  output_dir_option: Optional[str] = None,
                  output_file_option: Optional[str] = None,

--- a/scripts/mbedtls_framework/config_checks_generator.py
+++ b/scripts/mbedtls_framework/config_checks_generator.py
@@ -208,6 +208,17 @@ def generate_header_files(branch_data: BranchData,
 
 def main(branch_data: BranchData) -> None:
     root = build_tree.guess_project_root()
+    # Is root the current directory? The safe default is no, so compare
+    # the paths, rather than calling `os.samefile()` which can have false
+    # positives and can fail in edge cases.
+    if root == os.getcwd():
+        # Be nice and use a relative path when it's simple to do so.
+        # (build_tree.guess_project_root() should probably do this, actually.)
+        # This is not only nice to humans, but also necessary for
+        # `make_generated_files.py --root DIR --check`: it calls
+        # this script with `--list` and expects a path that is relative
+        # to DIR, not an absolute path that is under the project root.
+        root = os.curdir
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--list', action='store_true',
                         help='List generated files and exit')


### PR DESCRIPTION
When the current directory is the project root, have `--list` print relative paths, rather than absolute paths that start with
`build_treeguess_project_root()`.

This is not only nice to humans, but also necessary for `make_generated_files.py --root DIR --check`: it calls this script with `--list` and expects a path that is relative to DIR, not an absolute path that is under the project root.

Fix the build in https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/404, hopefully for real this time.

## PR checklist

Please add the numbers (or links) of the associated pull requests for consuming branches. You can omit branches where this pull request is not needed.

- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/404
- [x] **development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10340
- [x] **3.6 PR** not required because: new stuff
