### PR TITLE
[framework] Align header include guards with their new locations in TF PSA Crypto [1/3]

### DIFF
--- a/tests/programs/query_included_headers.c
+++ b/tests/programs/query_included_headers.c
@@ -11,18 +11,22 @@ int main(void)
 {
 
     /* Which PSA platform header? */
-#if defined(PSA_CRYPTO_PLATFORM_H)
+#if defined(PSA_CRYPTO_PLATFORM_H) || \
+    defined(TF_PSA_CRYPTO_PSA_CRYPTO_PLATFORM_H)
     mbedtls_printf("PSA_CRYPTO_PLATFORM_H\n");
 #endif
-#if defined(PSA_CRYPTO_PLATFORM_ALT_H)
+#if defined(PSA_CRYPTO_PLATFORM_ALT_H) || \
+    defined(TF_PSA_CRYPTO_PSA_CRYPTO_PLATFORM_ALT_H)
     mbedtls_printf("PSA_CRYPTO_PLATFORM_ALT_H\n");
 #endif
 
     /* Which PSA struct header? */
-#if defined(PSA_CRYPTO_STRUCT_H)
+#if defined(PSA_CRYPTO_STRUCT_H) || \
+    defined(TF_PSA_CRYPTO_PSA_CRYPTO_STRUCT_H)
     mbedtls_printf("PSA_CRYPTO_STRUCT_H\n");
 #endif
-#if defined(PSA_CRYPTO_STRUCT_ALT_H)
+#if defined(PSA_CRYPTO_STRUCT_ALT_H) || \
+    defined(TF_PSA_CRYPTO_PSA_CRYPTO_STRUCT_ALT_H)
     mbedtls_printf("PSA_CRYPTO_STRUCT_ALT_H\n");
 #endif
 


### PR DESCRIPTION
## Description

Prerequisite for https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/460

## PR checklist

- [ ] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/460
- [ ] **development PR** provided 
- [ ] **3.6 PR** not required because: no backport