### PR TITLE
Fix clang warning

### DIFF
--- a/tests/src/fake_external_rng_for_test.c
+++ b/tests/src/fake_external_rng_for_test.c
@@ -70,7 +70,7 @@ static size_t platform_get_entropy_forced_entropy_content = SIZE_MAX;
 static size_t platform_get_entropy_forced_output_len = SIZE_MAX;
 static size_t platform_get_entropy_call_count;
 
-void mbedtls_test_platform_get_entropy_reset()
+void mbedtls_test_platform_get_entropy_reset(void)
 {
     platform_get_entropy_call_count = 0;
     platform_get_entropy_force_failure = 0;
@@ -93,7 +93,7 @@ void mbedtls_test_platform_get_entropy_set_entropy_content(size_t val)
     platform_get_entropy_forced_entropy_content = val;
 }
 
-size_t mbedtls_test_platform_get_entropy_get_call_count()
+size_t mbedtls_test_platform_get_entropy_get_call_count(void)
 {
     return platform_get_entropy_call_count;
 }


### PR DESCRIPTION
## Description
Fix clang warning to unblock https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/445

## PR checklist
- [x] **TF-PSA-Crypto PR** not required because: framework only change
- [x] **development PR** not required because: framework only change
- [x] **3.6 PR** not required because: framework only change