### PR TITLE
Add adapted lcov.sh to the framework

### DIFF
--- a/scripts/lcov.sh
+++ b/scripts/lcov.sh
@@ -80,7 +80,7 @@ elif in_mbedtls_repo; then
     title='Mbed TLS < 4.0'
 elif in_tf_psa_crypto_repo; then
     library_dirs='core drivers/builtin'
-    title='TF-PSA-CRYPTO'
+    title='TF-PSA-Crypto'
 else
     echo "Cannot auto detect build files"
     exit


### PR DESCRIPTION
## Description

Add adapted lcov.sh to the framework. I've uploaded the rudimentary test script that I used to validate the change here https://github.com/bjwtaylor/mbedtls/blob/lcov-test/scripts/test.sh. It doesn't inspect the report, however it validates it has been created not sure if this is useful in this PR? Let me know what people think? contributes https://github.com/Mbed-TLS/mbedtls-framework/issues/93

This PR is part of a multistage PR, however the code changes involved appear to not effect the CI so it can be merged in any order. However it is suggested it is merged in the following order. 
1. https://github.com/Mbed-TLS/mbedtls-framework/pull/224 
2. https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/536  
3. https://github.com/Mbed-TLS/mbedtls/pull/10452 
4. https://github.com/Mbed-TLS/mbedtls/pull/10450

## PR checklist

- [x] **TF-PSA-Crypto PR** not required because: No changes 
- [x] **development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10450
- [x] **3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10452