### PR TITLE
AES-XTS: update test generation for double-size key handling

### DIFF
--- a/scripts/generate_psa_tests.py
+++ b/scripts/generate_psa_tests.py
@@ -253,6 +253,9 @@ class OpFail:
         arguments = [] # type: List[str]
         if kt:
             bits = kt.sizes_to_test()[0]
+            if pretty_alg == "XTS" and kt.can_do(alg):
+                # XTS mode uses double-size keys for the underlying block cipher
+                bits = bits * 2
             tc.set_key_bits(bits)
             tc.set_key_pair_usage(['IMPORT'])
             key_material = kt.key_material(bits)
@@ -638,6 +641,13 @@ class StorageFormat:
             compatible_algorithms = [alg for alg in all_algorithms
                                      if kt.can_do(alg)]
             for alg in compatible_algorithms:
+                if alg.expression == 'PSA_ALG_XTS':
+                    # XTS mode uses double-size keys for the underlying block cipher
+                    # XTS does not use 192-bit keys
+                    if bits != 192:
+                        bits = bits * 2
+                    else:
+                        continue
                 yield self.key_for_type_and_alg(kt, bits, alg)
 
     def all_keys_for_types(self) -> Iterator[StorageTestData]:

--- a/scripts/mbedtls_framework/crypto_knowledge.py
+++ b/scripts/mbedtls_framework/crypto_knowledge.py
@@ -226,6 +226,8 @@ class KeyType:
             if alg.head in ['CMAC', 'OFB'] and \
                self.head in ['ARIA', 'CAMELLIA']:
                 return False # not implemented in Mbed TLS
+            if alg.head == 'XTS' and self.head != 'AES':
+                return False # not implemented in Mbed TLS
             return True
         if self.head == 'CHACHA20' and alg.head == 'CHACHA20_POLY1305':
             return True


### PR DESCRIPTION
## Description

Update test scripts to handle AES-XTS double-size key requirements (256-bit and 512-bit keys) when PSA_ALG_XTS enabled. Changes are made in OpFail and Strorage Format tests.

## PR checklist

Please add the numbers (or links) of the associated pull requests for consuming branches. You can omit branches where this pull request is not needed.

- [x] **TF-PSA-Crypto PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/538
- [ ] **development PR** not required because: no changes
- [ ] **3.6 PR** provided # | not required because: no changes

