### PR TITLE
Release preparation script

### DIFF
--- a/data_files/test_certs.h.jinja2
+++ b/data_files/test_certs.h.jinja2
@@ -10,7 +10,7 @@
 
 {% for mode, name, value in macros %}
     {% if mode == 'string' %}
-/* This is taken from {{value}}. */
+/* This is taken from {{data_dir}}/{{value}}. */
 /* BEGIN FILE string macro {{name}} {{value}} */
 #define {{name}}{{ '\\' | put_to_column(position=80-9-name|length)}}
         {% for line in value | read_lines %}
@@ -21,7 +21,7 @@
 /* END FILE */
     {% endif %}
     {% if mode == 'binary' %}
-/* This is generated from {{value}}. */
+/* This is generated from {{data_dir}}/{{value}}. */
 /* BEGIN FILE binary macro {{name}} {{value}} */
 #define {{name}} {% raw -%} { {%- endraw %} {{ '\\' | put_to_column(position=80-11-name|length)}}
         {% for line in value | read_as_c_array %}

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -116,7 +116,7 @@ class TextChangelogFormat(ChangelogFormat):
         # Look for an incomplete release date
         return not re.search(r'[0-9x]{4}-[0-9x]{2}-[0-9x]?x', title)
 
-    _top_version_re = re.compile(r'(?:\A|\n)(=[^\n]*\n+)(.*?\n)(?:=|$)',
+    _top_version_re = re.compile(r'(?:\A|\n)(=[^\n]*\n)(.*?)(?:\n=|\Z)',
                                  re.DOTALL)
     _name_re = re.compile(r'=\s(.*)\s[0-9x]+\.', re.DOTALL)
     @classmethod
@@ -126,7 +126,7 @@ class TextChangelogFormat(ChangelogFormat):
         top_version_start = m.start(1)
         top_version_end = m.end(2)
         top_version_title = m.group(1)
-        top_version_body = m.group(2)
+        top_version_body = m.group(2).strip('\n') + '\n'
         name = re.match(cls._name_re, top_version_title).group(1)
         if cls.is_released_version(top_version_title):
             top_version_end = top_version_start
@@ -136,11 +136,12 @@ class TextChangelogFormat(ChangelogFormat):
                 top_version_title, top_version_body,
                 changelog_file_content[top_version_end:])
 
+    _newlines_only_re = re.compile(r'\n*\Z')
     _category_title_re = re.compile(r'(^\w.*)\n+', re.MULTILINE)
     @classmethod
     def split_categories(cls, version_body):
         """A category title is a line with the title in column 0."""
-        if not version_body:
+        if cls._newlines_only_re.match(version_body):
             return []
         title_matches = list(re.finditer(cls._category_title_re, version_body))
         if not title_matches or title_matches[0].start() != 0:

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -341,7 +341,8 @@ class EntryFileSortKey:
         text = subprocess.check_output(['git', 'show', '-s',
                                         '--format=%ct',
                                         commit_id])
-        return datetime.datetime.utcfromtimestamp(int(text))
+        return datetime.datetime.fromtimestamp(int(text),
+                                               datetime.timezone.utc)
 
     @staticmethod
     def file_timestamp(filename):

--- a/scripts/generate_test_cert_macros.py
+++ b/scripts/generate_test_cert_macros.py
@@ -16,40 +16,40 @@ import jinja2
 from mbedtls_framework.build_tree import guess_project_root
 
 TESTS_DIR = os.path.join(guess_project_root(), 'tests')
-FRAMEWORK_DIR = os.path.join(guess_project_root(), 'framework')
-DATA_FILES_PATH = os.path.join(FRAMEWORK_DIR, 'data_files')
+DATA_DIR_RELATIVE = 'framework/data_files'
+DATA_DIR_ABSOLUTE = os.path.join(guess_project_root(), DATA_DIR_RELATIVE)
 
 INPUT_ARGS = [
-    ("string", "TEST_CA_CRT_EC_PEM", DATA_FILES_PATH + "/test-ca2.crt"),
-    ("binary", "TEST_CA_CRT_EC_DER", DATA_FILES_PATH + "/test-ca2.crt.der"),
-    ("string", "TEST_CA_KEY_EC_PEM", DATA_FILES_PATH + "/test-ca2.key.enc"),
+    ("string", "TEST_CA_CRT_EC_PEM", "test-ca2.crt"),
+    ("binary", "TEST_CA_CRT_EC_DER", "test-ca2.crt.der"),
+    ("string", "TEST_CA_KEY_EC_PEM", "test-ca2.key.enc"),
     ("password", "TEST_CA_PWD_EC_PEM", "PolarSSLTest"),
-    ("binary", "TEST_CA_KEY_EC_DER", DATA_FILES_PATH + "/test-ca2.key.der"),
-    ("string", "TEST_CA_CRT_RSA_SHA256_PEM", DATA_FILES_PATH + "/test-ca-sha256.crt"),
-    ("binary", "TEST_CA_CRT_RSA_SHA256_DER", DATA_FILES_PATH + "/test-ca-sha256.crt.der"),
-    ("string", "TEST_CA_CRT_RSA_SHA1_PEM", DATA_FILES_PATH + "/test-ca-sha1.crt"),
-    ("binary", "TEST_CA_CRT_RSA_SHA1_DER", DATA_FILES_PATH + "/test-ca-sha1.crt.der"),
-    ("string", "TEST_CA_KEY_RSA_PEM", DATA_FILES_PATH + "/test-ca.key"),
+    ("binary", "TEST_CA_KEY_EC_DER", "test-ca2.key.der"),
+    ("string", "TEST_CA_CRT_RSA_SHA256_PEM", "test-ca-sha256.crt"),
+    ("binary", "TEST_CA_CRT_RSA_SHA256_DER", "test-ca-sha256.crt.der"),
+    ("string", "TEST_CA_CRT_RSA_SHA1_PEM", "test-ca-sha1.crt"),
+    ("binary", "TEST_CA_CRT_RSA_SHA1_DER", "test-ca-sha1.crt.der"),
+    ("string", "TEST_CA_KEY_RSA_PEM", "test-ca.key"),
     ("password", "TEST_CA_PWD_RSA_PEM", "PolarSSLTest"),
-    ("binary", "TEST_CA_KEY_RSA_DER", DATA_FILES_PATH + "/test-ca.key.der"),
-    ("string", "TEST_SRV_CRT_EC_PEM", DATA_FILES_PATH + "/server5.crt"),
-    ("binary", "TEST_SRV_CRT_EC_DER", DATA_FILES_PATH + "/server5.crt.der"),
-    ("string", "TEST_SRV_KEY_EC_PEM", DATA_FILES_PATH + "/server5.key"),
-    ("binary", "TEST_SRV_KEY_EC_DER", DATA_FILES_PATH + "/server5.key.der"),
-    ("string", "TEST_SRV_CRT_RSA_SHA256_PEM", DATA_FILES_PATH + "/server2-sha256.crt"),
-    ("binary", "TEST_SRV_CRT_RSA_SHA256_DER", DATA_FILES_PATH + "/server2-sha256.crt.der"),
-    ("string", "TEST_SRV_CRT_RSA_SHA1_PEM", DATA_FILES_PATH + "/server2.crt"),
-    ("binary", "TEST_SRV_CRT_RSA_SHA1_DER", DATA_FILES_PATH + "/server2.crt.der"),
-    ("string", "TEST_SRV_KEY_RSA_PEM", DATA_FILES_PATH + "/server2.key"),
-    ("binary", "TEST_SRV_KEY_RSA_DER", DATA_FILES_PATH + "/server2.key.der"),
-    ("string", "TEST_CLI_CRT_EC_PEM", DATA_FILES_PATH + "/cli2.crt"),
-    ("binary", "TEST_CLI_CRT_EC_DER", DATA_FILES_PATH + "/cli2.crt.der"),
-    ("string", "TEST_CLI_KEY_EC_PEM", DATA_FILES_PATH + "/cli2.key"),
-    ("binary", "TEST_CLI_KEY_EC_DER", DATA_FILES_PATH + "/cli2.key.der"),
-    ("string", "TEST_CLI_CRT_RSA_PEM", DATA_FILES_PATH + "/cli-rsa-sha256.crt"),
-    ("binary", "TEST_CLI_CRT_RSA_DER", DATA_FILES_PATH + "/cli-rsa-sha256.crt.der"),
-    ("string", "TEST_CLI_KEY_RSA_PEM", DATA_FILES_PATH + "/cli-rsa.key"),
-    ("binary", "TEST_CLI_KEY_RSA_DER", DATA_FILES_PATH + "/cli-rsa.key.der"),
+    ("binary", "TEST_CA_KEY_RSA_DER", "test-ca.key.der"),
+    ("string", "TEST_SRV_CRT_EC_PEM", "server5.crt"),
+    ("binary", "TEST_SRV_CRT_EC_DER", "server5.crt.der"),
+    ("string", "TEST_SRV_KEY_EC_PEM", "server5.key"),
+    ("binary", "TEST_SRV_KEY_EC_DER", "server5.key.der"),
+    ("string", "TEST_SRV_CRT_RSA_SHA256_PEM", "server2-sha256.crt"),
+    ("binary", "TEST_SRV_CRT_RSA_SHA256_DER", "server2-sha256.crt.der"),
+    ("string", "TEST_SRV_CRT_RSA_SHA1_PEM", "server2.crt"),
+    ("binary", "TEST_SRV_CRT_RSA_SHA1_DER", "server2.crt.der"),
+    ("string", "TEST_SRV_KEY_RSA_PEM", "server2.key"),
+    ("binary", "TEST_SRV_KEY_RSA_DER", "server2.key.der"),
+    ("string", "TEST_CLI_CRT_EC_PEM", "cli2.crt"),
+    ("binary", "TEST_CLI_CRT_EC_DER", "cli2.crt.der"),
+    ("string", "TEST_CLI_KEY_EC_PEM", "cli2.key"),
+    ("binary", "TEST_CLI_KEY_EC_DER", "cli2.key.der"),
+    ("string", "TEST_CLI_CRT_RSA_PEM", "cli-rsa-sha256.crt"),
+    ("binary", "TEST_CLI_CRT_RSA_DER", "cli-rsa-sha256.crt.der"),
+    ("string", "TEST_CLI_KEY_RSA_PEM", "cli-rsa.key"),
+    ("binary", "TEST_CLI_KEY_RSA_DER", "cli-rsa.key.der"),
 ]
 
 def main():
@@ -62,7 +62,8 @@ def main():
     if args.list_dependencies:
         files_list = [arg[2] for arg in INPUT_ARGS
                       if arg[0] != "password"]
-        print(" ".join(files_list))
+        print(" ".join(os.path.join(DATA_DIR_RELATIVE, filename)
+                       for filename in files_list))
         return
 
     generate(INPUT_ARGS, output=args.output)
@@ -71,20 +72,20 @@ def main():
 def generate(values=[], output=None):
     """Generate C header file.
     """
-    template_loader = jinja2.FileSystemLoader(DATA_FILES_PATH)
+    template_loader = jinja2.FileSystemLoader(DATA_DIR_ABSOLUTE)
     template_env = jinja2.Environment(
         loader=template_loader, lstrip_blocks=True, trim_blocks=True,
         keep_trailing_newline=True)
 
     def read_as_c_array(filename):
-        with open(filename, 'rb') as f:
+        with open(os.path.join(DATA_DIR_ABSOLUTE, filename), 'rb') as f:
             data = f.read(12)
             while data:
                 yield ', '.join(['{:#04x}'.format(b) for b in data])
                 data = f.read(12)
 
     def read_lines(filename):
-        with open(filename) as f:
+        with open(os.path.join(DATA_DIR_ABSOLUTE, filename)) as f:
             try:
                 for line in f:
                     yield line.strip()
@@ -102,7 +103,8 @@ def generate(values=[], output=None):
     template = template_env.get_template('test_certs.h.jinja2')
 
     with open(output, 'w') as f:
-        f.write(template.render(macros=values))
+        f.write(template.render(data_dir=DATA_DIR_RELATIVE,
+                                macros=values))
 
 
 if __name__ == '__main__':

--- a/scripts/generate_test_cert_macros.py
+++ b/scripts/generate_test_cert_macros.py
@@ -62,7 +62,7 @@ def main():
     if args.list_dependencies:
         files_list = [arg[2] for arg in INPUT_ARGS
                       if arg[0] != "password"]
-        print(" ".join(os.path.join(DATA_DIR_RELATIVE, filename)
+        print(" ".join(os.path.join(DATA_DIR_ABSOLUTE, filename)
                        for filename in files_list))
         return
 

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -337,16 +337,23 @@ class Step:
 
     def edit_file(self,
                   path: PathOrString,
-                  transform: Callable[[str], str]) -> None:
+                  transform: Callable[[str], str]) -> bool:
         """Edit a text file.
 
         The path can be relative to the toplevel root or absolute.
+
+        Return True if the file was modified, False otherwise.
         """
         with open(self.info.top_dir / path, 'r+', encoding='utf-8') as file_:
-            new_content = transform(file_.read())
-            file_.seek(0)
-            file_.truncate()
-            file_.write(new_content)
+            old_content = file_.read()
+            new_content = transform(old_content)
+            if old_content == new_content:
+                return False
+            else:
+                file_.seek(0)
+                file_.truncate()
+                file_.write(new_content)
+                return True
 
     def assert_preconditions(self) -> None:
         """Check whether the preconditions for this step have been achieved.

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -360,7 +360,9 @@ class Step:
 
         If not, raise an exception.
         """
-        self.assert_git_status()
+        if not self.files_are_clean():
+            raise Exception('There are uncommitted changes (maybe in submodules) in ' +
+                            str(self.info.top_dir))
 
     def run(self) -> None:
         """Perform the release preparation step.

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -420,6 +420,38 @@ class AssembleChangelogStep(Step):
                               'Assemble changelog and set release date')
 
 
+class BumpVersionStep(Step):
+    """Bump the product version and commit the result.
+
+    Do nothing if the product version is already as expected.
+
+    Note: this step does not check or affect submodules.
+
+    Note: this step does not currently handle ABI version bumps,
+    only product version bumps.
+    """
+
+    @classmethod
+    def name(cls) -> str:
+        return 'version'
+
+    # Files and directories that may contain version information.
+    FILES_WITH_VERSION = [
+        'CMakeLists.txt',
+        'doxygen',
+        'include',
+        'tests/suites',
+    ]
+
+    def run(self) -> None:
+        """Bump the product version if needed."""
+        subprocess.check_call(['scripts/bump_version.sh',
+                               '--version', self.info.version],
+                              cwd=self.info.top_dir)
+        self.git_commit_maybe(self.FILES_WITH_VERSION,
+                              'Bump version to ' + self.info.version)
+
+
 class ArchiveStep(Step):
     """Prepare release archives and the associated checksum file."""
 
@@ -582,6 +614,7 @@ class ArchiveStep(Step):
 
 ALL_STEPS = [
     AssembleChangelogStep,
+    BumpVersionStep,
     ArchiveStep,
 ] #type: Sequence[typing.Type[Step]]
 

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -796,19 +796,19 @@ def main() -> None:
                         help='Product toplevel directory')
     parser.add_argument('--artifact-directory', '-a',
                         help='Directory where release artifacts will be placed')
-    parser.add_argument('--from', metavar='STEP',
+    parser.add_argument('--from', '-f', metavar='STEP',
                         dest='from_',
                         help='First step to run (default: run all steps)')
     parser.add_argument('--list-steps',
                         action='store_true',
                         help='List release steps and exit')
-    parser.add_argument('--release-date',
+    parser.add_argument('--release-date', '-d',
                         help='Release date (YYYY-mm-dd) (default: today)')
     parser.add_argument('--release-version', '-r',
                         help='The version to release (default/empty: from ChangeLog)')
     parser.add_argument('--tar-command',
                         help='GNU tar command')
-    parser.add_argument('--to', metavar='STEP',
+    parser.add_argument('--to', '-t', metavar='STEP',
                         help='Last step to run (default: run all steps)')
     parser.set_defaults(**DEFAULT_OPTIONS._asdict())
     args = parser.parse_args()

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -295,7 +295,7 @@ class Step:
         and may not be in a submodule of `where`.
         """
         try:
-            self.call_git(['diff', '--quiet', '--'] + list(files),
+            self.call_git(['diff', '--quiet', 'HEAD', '--'] + list(files),
                           where=where)
             return True
         except subprocess.CalledProcessError as exn:

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -98,16 +98,16 @@ class Options(typing.NamedTuple):
     artifact_directory: pathlib.Path
     # Release date (YYYY-mm-dd).
     release_date: str
+    # Version to release (empty to read it from ChangeLog).
+    release_version: str
     # GNU tar command.
     tar_command: str
-    # Version to release (None to read it from ChangeLog).
-    version: Optional[str]
 
 DEFAULT_OPTIONS = Options(
     artifact_directory=pathlib.Path(os.pardir),
     release_date=datetime.date.today().isoformat(),
-    tar_command=find_gnu_tar(),
-    version=None)
+    release_version='',
+    tar_command=find_gnu_tar())
 
 
 class Info:
@@ -155,10 +155,10 @@ class Info:
         """
         self.top_dir = pathlib.Path(top_dir)
         self._read_product_info()
-        if options.version is None:
-            self._release_version = self.old_version
+        if options.release_version:
+            self._release_version = options.release_version
         else:
-            self._release_version = options.version
+            self._release_version = self.old_version
         self._product_machine_name = \
             self._product_machine_name_from_human_name(self._product_human_name)
 
@@ -804,12 +804,12 @@ def main() -> None:
                         help='List release steps and exit')
     parser.add_argument('--release-date',
                         help='Release date (YYYY-mm-dd) (default: today)')
+    parser.add_argument('--release-version', '-r',
+                        help='The version to release (default/empty: from ChangeLog)')
     parser.add_argument('--tar-command',
                         help='GNU tar command')
     parser.add_argument('--to', metavar='STEP',
                         help='Last step to run (default: run all steps)')
-    parser.add_argument('version', nargs='?',
-                        help='The version to release (default: from ChangeLog)')
     parser.set_defaults(**DEFAULT_OPTIONS._asdict())
     args = parser.parse_args()
     if args.list_steps:
@@ -819,8 +819,8 @@ def main() -> None:
     options = Options(
         artifact_directory=pathlib.Path(args.artifact_directory).absolute(),
         release_date=args.release_date,
-        tar_command=args.tar_command,
-        version=args.version)
+        release_version=args.release_version,
+        tar_command=args.tar_command)
     run(options, args.directory,
         from_=args.from_, to=args.to)
 

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Prepare to release TF-PSA-Crypto or Mbed TLS.
+
+This script constructs a release candidate branch and release artifacts.
+It must run from a clean git worktree with initialized, clean git submodules.
+When making an Mbed TLS >=4 release, the tf-psa-crypto submodule should
+already contain a TF-PSA-Crypto release candidate.
+"""
+
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+################################################################
+
+#### Tips for maintainers ####
+
+# This script insists on having a clean git checkout, including
+# submodules. If you want to modify it, either make your changes in
+# a separate worktree, or commit your changes first and update
+# submodules in the parent repositories.
+
+#### Architectural notes ####
+
+# The process of preparing a release consists of some information
+# gathering about the branch to release in the `Info` class, then
+# a series of steps in `XxxStep` classes.
+
+# Information gathering is performed by the `Info` constructor.
+# Any failure causes the script to abort.
+
+# The steps run sequentially in the order defined by `ALL_STEPS`.
+# Each step starts by checking precondition in `step.assert_preconditions()`,
+# then does its job in `step.run()`. `assert_preconditions` should
+# not change any state. `run` is expected to change state and is
+# not expected to clean up if an error occurs.
+
+# This script is expected to perform a release reliably, so it
+# should try to detect dodgy conditions and abort. It should avoid
+# silently outputting garbage. Nonetheless, human review of the
+# result is still expected.
+
+################################################################
+
+
+import argparse
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import typing
+from typing import Dict, List, Optional, Sequence
+
+
+PathOrString = typing.Union[os.PathLike, str]
+
+
+class InformationGatheringError(Exception):
+    """Problem detected while gathering information."""
+    pass
+
+
+class Options(typing.NamedTuple):
+    """Options controlling the behavior of the release process.
+
+    Each field here should have an associated command line option
+    declared in main().
+    """
+    # Directory where the release artifacts will be placed.
+    artifact_directory: pathlib.Path
+    # Version to release (None to read it from ChangeLog).
+    version: Optional[str]
+
+DEFAULT_OPTIONS = Options(
+    artifact_directory=pathlib.Path(os.pardir),
+    version=None)
+
+
+class Info:
+    """Information about the intended release.
+
+    This class contains information gathered from the product tree as well
+    as from the command line.
+    """
+
+    def _read_product_info(self) -> None:
+        """Read information from the source files."""
+        with open(self.top_dir / 'ChangeLog', encoding='utf-8') as changelog:
+            # We deliberately read only a short portion at the top of the
+            # changelog file. This reduces the risk that we'll match an
+            # older release if the content near the top of the file doesn't
+            # have the expected format.
+            head = changelog.read(1000)
+            m = re.search(r'^= *(.*?) +([0-9][-.0-9A-Za-z]+) +branch released (\S+)\n',
+                          head, re.M)
+            if not m:
+                raise InformationGatheringError(
+                    'Could not find version header line near the top of ChangeLog')
+            self._product_human_name = m.group(1)
+            self.old_version = m.group(2)
+            self.old_release_date = m.group(3)
+
+    @staticmethod
+    def _product_machine_name_from_human_name(_human_name: str) -> str:
+        """Determine the name used in release tags and file names."""
+        if _human_name == 'TF-PSA-Crypto':
+            return 'tf-psa-crypto'
+        elif _human_name == 'Mbed TLS':
+            return 'mbedtls'
+        else:
+            raise InformationGatheringError(
+                f'Could not determine product (found "{_human_name}" in ChangeLog)')
+
+    def __init__(self, top_dir: str, options: Options) -> None:
+        """Parse the source files to obtain information about the product.
+
+        Look for the product under `top_dir`.
+
+        Optional parameters can override the supplied information:
+        * `version`: version to release.
+        """
+        self.top_dir = pathlib.Path(top_dir)
+        self._read_product_info()
+        if options.version is None:
+            self._release_version = self.old_version
+        else:
+            self._release_version = options.version
+        self._product_machine_name = \
+            self._product_machine_name_from_human_name(self._product_human_name)
+
+    @property
+    def product_human_name(self) -> str:
+        """Human-readable product name, e.g. 'Mbed TLS'."""
+        return self._product_human_name
+
+    @property
+    def product_machine_name(self) -> str:
+        """Machine-frieldly product name, e.g. 'mbedtls'."""
+        return self._product_machine_name
+
+    @property
+    def version(self) -> str:
+        """Version string for the relase."""
+        return self._release_version
+
+
+class Step:
+    """A step on the release process.
+
+    This is an abstract class containing some common tooling.
+    Subclasses must provide the following methods:
+    * `name()` returning a unique name for each step.
+    * `run()` doing the work. Raise an exception if something goes wrong.
+
+    Subclasses may override the following methods:
+    * `assert_preconditions()` is called to perform sanity checks before
+      calling `run()`.
+    """
+
+    @classmethod
+    def name(cls) -> str:
+        """The name of this step."""
+        raise NotImplementedError
+
+    def __init__(self, options: Options, info: Info) -> None:
+        """Instantiate the release step for the given product directory.
+
+        This constructor may analyze the contents of the product tree,
+        but it does not require other steps to have run.
+        """
+        self.options = options
+        self.info = info
+        self._submodules = None #type: Optional[List[str]]
+
+    @staticmethod
+    def _git_command(subcommand: List[str],
+                     where: Optional[PathOrString] = None) -> List[str]:
+        cmd = ['git']
+        if where is not None:
+            cmd += ['-C', str(where)]
+        return cmd + subcommand
+
+    def call_git(self, cmd: List[str],
+                 where: Optional[PathOrString] = None,
+                 env: Optional[Dict[str, str]] = None) -> None:
+        """Run git in the source tree.
+
+        Pass `where` to specify a submodule.
+        """
+        subprocess.check_call(self._git_command(cmd, where),
+                              cwd=self.info.top_dir,
+                              env=env)
+
+    def read_git(self, cmd: List[str],
+                 where: Optional[PathOrString] = None,
+                 env: Optional[Dict[str, str]] = None) -> bytes:
+        """Run git in the source tree and return the output.
+
+        Pass `where` to specify a submodule.
+        """
+        return subprocess.check_output(self._git_command(cmd, where),
+                                       cwd=self.info.top_dir,
+                                       env=env)
+
+    @property
+    def submodules(self) -> Sequence[str]:
+        """List the git submodules (recursive, but not including the top level)."""
+        if self._submodules is None:
+            raw = self.read_git(['submodule', '--quiet',
+                                 'foreach', '--recursive',
+                                 'printf %s\\\\0 "$displaypath"'])
+            self._submodules = raw.decode('ascii').rstrip('\0').split('\0')
+        return self._submodules
+
+    def assert_git_status(self) -> None:
+        """Abort if the working directory is not clean (no git changes).
+
+        This includes git submodules.
+        """
+        self.call_git(['diff', '--quiet'])
+
+
+    def assert_preconditions(self) -> None:
+        """Check whether the preconditions for this step have been achieved.
+
+        If not, raise an exception.
+        """
+        self.assert_git_status()
+
+    def run(self) -> None:
+        """Perform the release preparation step.
+
+        This may create commits in the source tree or its submodules.
+        """
+        raise NotImplementedError
+
+
+ALL_STEPS = [
+] #type: Sequence[typing.Type[Step]]
+
+
+def run(options: Options,
+        top_dir: str,
+        from_: Optional[str] = None,
+        to: Optional[str] = None) -> None:
+    """Run the release process (or a segment thereof)."""
+    info = Info(top_dir, options)
+    from_reached = (from_ is None)
+    for step_class in ALL_STEPS:
+        step = step_class(options, info)
+        if not from_reached:
+            if step.name() != from_:
+                continue
+            from_reached = True
+        step.assert_preconditions()
+        step.run()
+        if step.name() == to:
+            break
+
+def main() -> None:
+    """Command line entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    # Options that affect information gathering, or that affect the
+    # behavior of one or more steps, should have an associated field
+    # in the Options class.
+    parser.add_argument('--directory',
+                        default=os.curdir,
+                        help='Product toplevel directory')
+    parser.add_argument('--artifact-directory', '-a',
+                        help='Directory where release artifacts will be placed')
+    parser.add_argument('--from', metavar='STEP',
+                        dest='from_',
+                        help='First step to run (default: run all steps)')
+    parser.add_argument('--list-steps',
+                        action='store_true',
+                        help='List release steps and exit')
+    parser.add_argument('--to', metavar='STEP',
+                        help='Last step to run (default: run all steps)')
+    parser.add_argument('version', nargs='?',
+                        help='The version to release (default: from ChangeLog)')
+    parser.set_defaults(**DEFAULT_OPTIONS._asdict())
+    args = parser.parse_args()
+    if args.list_steps:
+        for step in ALL_STEPS:
+            sys.stdout.write(step.name() + '\n')
+        return
+    options = Options(
+        artifact_directory=pathlib.Path(args.artifact_directory).absolute(),
+        version=args.version)
+    run(options, args.directory,
+        from_=args.from_, to=args.to)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -603,6 +603,10 @@ class ArchiveStep(Step):
             project_dir = self.info.top_dir / project
             project_prefix = (prefix if project == os.curdir else
                               prefix + project + '/')
+            gen_script = project_dir / 'framework/scripts/make_generated_files.py'
+            # Skip submodules that do not use the framework build machinery.
+            if not gen_script.exists():
+                continue
             file_list = self.list_project_generated_files(project_dir)
             self.update_project_generated_files(project_dir)
             self.tar_add_project_generated_files(plain_tar_path,

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -98,6 +98,9 @@ class Options(typing.NamedTuple):
     # Directory where the release artifacts will be placed.
     # If None: "{source_directory}/release-artifacts"
     artifact_directory: Optional[pathlib.Path]
+    # Whether to go ahead if submodules are out of date or if there
+    # are modified files inside submodules.
+    ignore_submodules: bool
     # Release date (YYYY-mm-dd).
     release_date: str
     # Version to release (empty to read it from ChangeLog).
@@ -107,6 +110,7 @@ class Options(typing.NamedTuple):
 
 DEFAULT_OPTIONS = Options(
     artifact_directory=None,
+    ignore_submodules=False,
     release_date=datetime.date.today().isoformat(),
     release_version='',
     tar_command=find_gnu_tar())
@@ -316,6 +320,7 @@ class Step:
         self.call_git(['diff', '--quiet'])
 
     def files_are_clean(self, *files: str,
+                        ignore_submodules: Optional[str] = None,
                         where: Optional[PathOrString] = None) -> bool:
         """Check whether the specified files are identical to their git version.
 
@@ -326,8 +331,12 @@ class Step:
         and may not be in a submodule of `where`.
         """
         try:
-            self.call_git(['diff', '--quiet', 'HEAD', '--'] + list(files),
-                          where=where)
+            cmd = ['diff', '--quiet']
+            if ignore_submodules:
+                cmd += ['--ignore-submodules=' + ignore_submodules]
+            cmd += ['HEAD', '--']
+            cmd += list(files)
+            self.call_git(cmd, where=where)
             return True
         except subprocess.CalledProcessError as exn:
             if exn.returncode != 1:
@@ -391,7 +400,11 @@ class Step:
 
         If not, raise an exception.
         """
-        if not self.files_are_clean():
+        if self.options.ignore_submodules:
+            ignore_submodules = 'all'
+        else:
+            ignore_submodules = 'none'
+        if not self.files_are_clean(ignore_submodules=ignore_submodules):
             raise Exception('There are uncommitted changes (maybe in submodules) in ' +
                             str(self.info.top_dir))
 
@@ -836,6 +849,9 @@ def main() -> None:
                               '(default/empty: <--directory>/release-artifacts)'))
     parser.add_argument('--from-step', '--from', '-f', metavar='STEP',
                         help='First step to run (default: run all steps)')
+    parser.add_argument('--ignore-submodules',
+                        action='store_true',
+                        help='Ignore changes to submodules and changed files within submodules')
     parser.add_argument('--list-steps',
                         action='store_true',
                         help='List release steps and exit')
@@ -868,6 +884,7 @@ def main() -> None:
         artifact_directory = pathlib.Path(args.artifact_directory)
     options = Options(
         artifact_directory=artifact_directory,
+        ignore_submodules=args.ignore_submodules,
         release_date=args.release_date,
         release_version=args.release_version,
         tar_command=args.tar_command)

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -9,6 +9,7 @@ This script will update the checked out git branch, if any.
 On normal exit, the worktree contains the release candidate commit.
 
 This script requires the following external tools:
+- Git >= 2.40.0 (for ``git archive --mtime=...``).
 - GNU tar (can be called ``gnutar`` or ``gtar``);
 - ``sha256sum``.
 """
@@ -509,6 +510,7 @@ class ArchiveStep(Step):
         # an exact commit, we should make sure that the commit gets published.
         index = self.git_index_as_tree_ish()
         mtime = self.commit_timestamp()
+        # Note that `git archive --mtime=...` requires Git >= 2.40.0.
         self.call_git(['archive', '--format=tar',
                        '--mtime', str(mtime),
                        '--prefix', prefix,

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -133,26 +133,22 @@ class Info:
         return cmd + subcommand
 
     def call_git(self, cmd: List[str],
-                 where: Optional[PathOrString] = None,
-                 env: Optional[Dict[str, str]] = None) -> None:
+                 where: Optional[PathOrString] = None) -> None:
         """Run git in the source tree.
 
         Pass `where` to specify a submodule.
         """
         subprocess.check_call(self._git_command(cmd, where),
-                              cwd=self.top_dir,
-                              env=env)
+                              cwd=self.top_dir)
 
     def read_git(self, cmd: List[str],
-                 where: Optional[PathOrString] = None,
-                 env: Optional[Dict[str, str]] = None) -> bytes:
+                 where: Optional[PathOrString] = None) -> bytes:
         """Run git in the source tree and return the output.
 
         Pass `where` to specify a submodule.
         """
         return subprocess.check_output(self._git_command(cmd, where),
-                                       cwd=self.top_dir,
-                                       env=env)
+                                       cwd=self.top_dir)
 
     def _read_file_tree(self) -> None:
         """Find information about files in this branch."""
@@ -263,22 +259,20 @@ class Step:
             self.artifact_directory = pathlib.Path(options.artifact_directory).absolute()
 
     def call_git(self, cmd: List[str],
-                 where: Optional[PathOrString] = None,
-                 env: Optional[Dict[str, str]] = None) -> None:
+                 where: Optional[PathOrString] = None) -> None:
         """Run git in the source tree.
 
         Pass `where` to specify a submodule.
         """
-        self.info.call_git(cmd, where=where, env=env)
+        self.info.call_git(cmd, where=where)
 
     def read_git(self, cmd: List[str],
-                 where: Optional[PathOrString] = None,
-                 env: Optional[Dict[str, str]] = None) -> bytes:
+                 where: Optional[PathOrString] = None) -> bytes:
         """Run git in the source tree and return the output.
 
         Pass `where` to specify a submodule.
         """
-        return self.info.read_git(cmd, where=where, env=env)
+        return self.info.read_git(cmd, where=where)
 
     def commit_timestamp(self,
                          where: Optional[PathOrString] = None,

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -432,15 +432,6 @@ class AssembleChangelogStep(Step):
                       new_section,
                       old_content, flags=re.MULTILINE, count=1)
 
-    def release_date_needs_updating(self) -> bool:
-        """Whether the release date needs updating in the existing ChangeLog section."""
-        m = re.match(r'([0-9]+)-([0-9]+)-([0-9]+)', self.info.old_release_date)
-        if not m: # presumably xxxx-xx-xx
-            return True
-        # The date format is a lexicographic-order, fixed-width format,
-        # so we can just compare the strings.
-        return self.info.old_release_date < self.options.release_date
-
     def finalize_release(self, old_content: str) -> str:
         """Update the version and release date in the changelog content."""
         version = self.info.version

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -214,7 +214,7 @@ class Info:
 
     @property
     def product_machine_name(self) -> str:
-        """Machine-frieldly product name, e.g. 'mbedtls'."""
+        """Machine-friendly product name, e.g. 'mbedtls'."""
         return self._product_machine_name
 
     @property
@@ -228,7 +228,7 @@ class Info:
 
     @property
     def version(self) -> str:
-        """Version string for the relase."""
+        """Version string for the release."""
         return self._release_version
 
 
@@ -443,7 +443,7 @@ class AssembleChangelogStep(Step):
         m = re.match(r'([0-9]+)-([0-9]+)-([0-9]+)', self.info.old_release_date)
         if not m: # presumably xxxx-xx-xx
             return True
-        # The date format is a lexicographic, fixed-width format,
+        # The date format is a lexicographic-order, fixed-width format,
         # so we can just compare the strings.
         return self.info.old_release_date < self.options.release_date
 
@@ -527,7 +527,7 @@ class ArchiveStep(Step):
         self.call_git(['archive', '--format=tar',
                        '--mtime', str(mtime),
                        '--prefix', prefix,
-                       '--output', str(plain_tar_path),
+                       '--output', plain_tar_path,
                        index])
         for submodule in self.info.submodules:
             index = self.git_index_as_tree_ish(where=submodule)
@@ -588,7 +588,7 @@ class ArchiveStep(Step):
 
     @staticmethod
     def update_project_generated_files(project_dir: pathlib.Path) -> None:
-        """Update the list of generated files in the given (sub)project."""
+        """Regenerate the generated files in the given (sub)project."""
         subprocess.check_call(
             ['framework/scripts/make_generated_files.py'],
             cwd=project_dir)


### PR DESCRIPTION
Create a release preparation script. Resolves https://github.com/Mbed-TLS/mbedtls-framework/issues/232.

This script performs the following steps:

* Assemble the changelog.
* Bump version. Currently only supports bumping the product version, not the SO version (ABI). Currently relies on `bump_version.sh` which doesn't exist in TF-PSA-Crypto, it could be adapted to be standalone at little effort.
* Create a release archive that includes the generated files and that has `GEN_FILES` off. Uses GNU tar. Also create a shasum file.
* Create some draft release notes. This doesn't do a complete job, I've just tried to automate the bits that are easy to automate.

Features:

* Creates git commits for the parts that go into the release tag (version bump, changelog finalization).
* The resulting archive should be reproducible (with the same tooling versions, and starting from the same commit), but I haven't tested this much.
* Tries to be robust and just give up if something looks wrong.

Limitations:

* Currently only supports releases as we've done TF-PSA-Crypto 1.0.0 and Mbed TLS 4.0.0, not what we do for 3.6.x where we commit generated files. I'm not sure if it's worth it to also support the 3.6.x structure. It depends partly on how we'll to 1.x/4.x LTS releases.
* No support (yet) for bumping the ABI version.
* Relies on GNU tar. We could use Python built-in archive support instead. I think it would actually make the code simpler, but it would increase our dependent on this script: with GNU tar, it's still doable to create a similar archive manually.
* The Mbed TLS release does not check if TF-PSA-Crypto seems to be in a releasable state. You're supposed to run the release script in TF-PSA-Crypto first, then update the submodule in Mbed TLS, but this is not enforced.
* Does not do anything about tags.
* Enforcing any kind of consistency between releases is completely out of scope.
* Output verbosity is not always optimal and not configurable. I think that's ok for MVP and can be improved later.
* Running this script on the CI is out of scope (covered by https://github.com/Mbed-TLS/mbedtls/issues/3255).
* I put the executable script directly in the framework, so it can't be customized per branch. I think that's ok, because changes to the release process tend to involve considerations of all the releasable branches. We can have branch-dependent behavior in the script.

Contributes to:

* https://github.com/Mbed-TLS/mbedtls/issues/3255 (this creates a script that we can run on the CI, but we'll need extra effort to run it in `all.sh` and upload the generated artifacts).
* https://github.com/Mbed-TLS/mbedtls/issues/9521 (fixes the known problem, does not add a non-regression test).
* Fixes https://github.com/Mbed-TLS/mbedtls/issues/10337.
* Durably fixes https://github.com/Mbed-TLS/mbedtls/issues/9524, https://github.com/Mbed-TLS/mbedtls/issues/10121, https://github.com/Mbed-TLS/mbedtls/issues/10332.

## PR checklist

- [x] **TF-PSA-Crypto PR** provided # | not required because: standalone script
- [x] **development PR** provided # | not required because: standalone script
- [x] **3.6 PR** provided # | not required because: standalone script
