### PR TITLE
Fix make_generated_files --check

### DIFF
--- a/scripts/make_generated_files.py
+++ b/scripts/make_generated_files.py
@@ -242,6 +242,7 @@ def check_generated_files(generation_scripts: List[GenerationScript],
                 # there's nothing to compare to, or clean up.
                 continue
             if not filecmp.cmp(file, bak_file):
+                ok = False
                 ref_file = file.with_name(file.name + ".ref")
                 ref_file = root / ref_file
                 if ref_file.exists():


### PR DESCRIPTION
Fix #244

Needs preceding PR: 
* https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/646 and https://github.com/Mbed-TLS/mbedtls/pull/10555 to fix non-determinism in the generation of `*_config_check_user.h`. Note that https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/646 needs to reach the tf-psa-crypto submodule of mbedtls.

Needed soon after: fix https://github.com/Mbed-TLS/mbedtls/issues/10529 — framework discrepancies can cause differences in generated files. I have a fix for that in https://github.com/Mbed-TLS/mbedtls/pull/10530 but it conflicts with the makefile move in https://github.com/Mbed-TLS/mbedtls/pull/10543 and follow-ups. I propose to do the makefile move first, then fix https://github.com/Mbed-TLS/mbedtls/issues/10529 inside TF-PSA-Crypto. We can merge the `make_generated_files` check fix in the meantime because right now the framework is the same in both repositories and we don't have pending breaking changes.

## PR checklist

- [x] **TF-PSA-Crypto PR** not required because: only really problematic in mbedtls
- [x] **development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10530 as a prerequisite. We can later update the mbedtls framework at our leasure.
- [x] **3.6 PR** not required because: only really problematic in mbedtls



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
