### PR TITLE
Remove dirty fix for secp192 curves added in #570

### DIFF
--- a/scripts/generate_test_keys.py
+++ b/scripts/generate_test_keys.py
@@ -179,6 +179,8 @@ def main() -> None:
     # tf-psa-crypto. It only remains available for 3.6 LTS branch.
     if not build_tree.is_mbedtls_3_6():
         del EC_NAME_CONVERSION['PSA_ECC_FAMILY_SECP_R1'][224]
+        del EC_NAME_CONVERSION['PSA_ECC_FAMILY_SECP_R1'][192]
+        del EC_NAME_CONVERSION['PSA_ECC_FAMILY_SECP_K1'][192]
 
     arrays, look_up_table = collect_keys()
 


### PR DESCRIPTION
## Description

Contributes to https://github.com/Mbed-TLS/TF-PSA-Crypto/issues/591

~Depends on https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/570~

## PR checklist

- [ ] **TF-PSA-Crypto PR** not required: there will be a follow-up PR in tf-psa-crypto to completely resolve #591, but this can happen at any time, it's not urgent.
- [ ] **development PR** not required: no change there.
- [ ] **3.6 PR** not required because: no backport