### PR TITLE
Only clean CMake artifacts in-tree

### DIFF
--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -396,9 +396,9 @@ cleanup()
     # subdirectories.
     # Remove **/Makefile only if it looks like it was created by an in-tree
     # CMake build.
-    local cmake_dirs=($(list_git_files 'CMakeLists.txt' '**/CMakeLists.txt' |
-                        sed -e 's![^/]*$!!'))
-    for d in "${cmake_dirs[@]}"; do
+    local cmakelists=($(list_git_files 'CMakeLists.txt' '**/CMakeLists.txt'))
+    for f in "${cmakelists[@]}"; do
+        local d="$(dirname -- "$f")"
         if [ -d "$d/CMakeFiles" ]; then
             rm -rf "$d/CMakeFiles" \
                "$d/cmake_install.cmake" \


### PR DESCRIPTION
Remove a major annoyance for maintainers who use ninja. Fixes https://github.com/Mbed-TLS/mbedtls-framework/issues/252

## PR checklist

- [x] **TF-PSA-Crypto PR** not required because: no product impact
- [x] **development PR** not required because: no product impact
- [x] **3.6 PR** provided # | not required because: no product impact
