### PR TITLE
test_driver_signature: Converted helper methods to static

### DIFF
--- a/tests/src/drivers/test_driver_signature.c
+++ b/tests/src/drivers/test_driver_signature.c
@@ -53,7 +53,7 @@ mbedtls_test_driver_signature_hooks_t
 mbedtls_test_driver_signature_hooks_t
     mbedtls_test_driver_signature_verify_hooks = MBEDTLS_TEST_DRIVER_SIGNATURE_INIT;
 
-psa_status_t sign_hash(
+static psa_status_t sign_hash(
     const psa_key_attributes_t *attributes,
     const uint8_t *key_buffer,
     size_t key_buffer_size,
@@ -121,7 +121,7 @@ psa_status_t sign_hash(
     return PSA_ERROR_NOT_SUPPORTED;
 }
 
-psa_status_t verify_hash(
+static psa_status_t verify_hash(
     const psa_key_attributes_t *attributes,
     const uint8_t *key_buffer,
     size_t key_buffer_size,


### PR DESCRIPTION
## Description

This minor pr changes the scope of test driver's [test_driver_signature.c](https://github.com/Mbed-TLS/mbedtls-framework/blob/main/tests/src/drivers/test_driver_signature.c) specific methods of file `psa_status_t verify_hash/sign/hash` to be static. 

Under the makefile build system when the component_test_psa_crypto_drivers is build the compilation flag of  [-Werror,-Wmissing-prototypes] is not used. But with the transition to cmake this passed on throughout our build systems. 


## PR checklist

Please add the numbers (or links) of the associated pull requests for consuming branches. You can omit branches where this pull request is not needed.

- [ ] **TF-PSA-Crypto PR** provided # | not required because: 
- [ ] **development PR** provided # | not required because: 
- [ ] **3.6 PR** provided # | not required because: 


