### PR TITLE
Framework: Split crypto part of Mbed TLS makefiles

### DIFF
--- a/scripts/generate_test_cert_macros.py
+++ b/scripts/generate_test_cert_macros.py
@@ -60,7 +60,8 @@ def main():
     args = parser.parse_args()
 
     if args.list_dependencies:
-        files_list = [arg[2] for arg in INPUT_ARGS]
+        files_list = [arg[2] for arg in INPUT_ARGS
+                      if arg[0] != "password"]
         print(" ".join(files_list))
         return
 


### PR DESCRIPTION
Prerequisite for https://github.com/Mbed-TLS/mbedtls/pull/10543

Fix non-file elements appearing in
`generate_test_cert_macros.py --list-dependencies`. That only worked because Mbed TLS didn't call it as intended (not done in `CMakeLists.txt` or `make_generated_files.py`, and [buggy](https://github.com/Mbed-TLS/mbedtls/commit/815c6563d2707dc007708db2475716cc3b3c8e7d) in `tests/Makefile`).

## PR checklist

- [ ] **TF-PSA-Crypto PR** required for TODO (follow-up of https://github.com/Mbed-TLS/mbedtls/pull/10543)
- [x] **development PR** required for ~https://github.com/Mbed-TLS/mbedtls/pull/10541~ https://github.com/Mbed-TLS/mbedtls/pull/10543
- [x] **3.6 PR** not required unless we backport the minor bug fix mentioned in https://github.com/Mbed-TLS/mbedtls/pull/10543
