### PR TITLE
all.sh: fail if a file is missing on a "not grep ..." line

### DIFF
--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -810,10 +810,7 @@ pre_setup_keep_going () {
 ## to be failed.
 not_grep () {
     declare ret=0
-    # Add /dev/null as a file name. This forces the file name to be displayed
-    # if there is a single file name, and prevents blocking waiting on stdin
-    # if this function is accidentally called with zero file names.
-    grep "$@" /dev/null || ret=$?
+    grep -H "$@" || ret=$?
     if [[ $ret -eq 0 ]]; then
         # A match was found, and displayed on stdout.
         # This is a test failure.

--- a/scripts/all-core.sh
+++ b/scripts/all-core.sh
@@ -740,6 +740,7 @@ pre_setup_keep_going () {
             *test*) true;; # make test, tests/stuff, env V=v tests/stuff, ...
             *make*check*) true;;
             "grep "*) true;;
+            "not_grep "*) true;;
             "[ "*) true;;
             "! "*) true;;
             *) false;;
@@ -802,9 +803,47 @@ pre_setup_keep_going () {
     }
 }
 
+## not_grep [GREP_OPTION...] REGEXP FILE[...]
+## Assert that none of the files contains a match for REGEXP.
+## Errors such as a missing file are also assertion failures.
+## If the assertion fails, print an error and consider the test case
+## to be failed.
+not_grep () {
+    declare ret=0
+    # Add /dev/null as a file name. This forces the file name to be displayed
+    # if there is a single file name, and prevents blocking waiting on stdin
+    # if this function is accidentally called with zero file names.
+    grep "$@" /dev/null || ret=$?
+    if [[ $ret -eq 0 ]]; then
+        # A match was found, and displayed on stdout.
+        # This is a test failure.
+        report_failed_command="not_grep $*"
+        false
+        unset report_failed_command
+    elif [[ $ret -ne 1 ]]; then
+        # If grep exited with error code 1, grep ran find and found that
+        # there were no matches, which means the assertion is true.
+        # If grep exited with an error code >=2, then something went
+        # wrong, probably a missing file (or e.g. a command syntax error).
+        # grep already printed an error message, so we just need to assert
+        # the condition and the ERR trap will mark the test case as failed.
+        # But make sure that the failure report indicates the grep command.
+        report_failed_command="not_grep $*"
+        (exit $ret)
+        unset report_failed_command
+    fi
+}
+
 # '! true' does not trigger the ERR trap. Arrange to trigger it, with
 # a reasonably informative error message (not just "$@").
 not () {
+    # "not grep" is fragile and should not be used.
+    # https://github.com/Mbed-TLS/mbedtls-framework/issues/266
+    if [ "$1" = "grep" ]; then
+        shift
+        not_grep "$@"
+        return
+    fi
     if "$@"; then
         report_failed_command="! $*"
         false


### PR DESCRIPTION
Fixes https://github.com/Mbed-TLS/mbedtls-framework/issues/266

This is transparent since `not grep` automatically redirects to the new function. I'm not sure whether this should be transitional or if we should keep this automation.

Needs preceding PR: https://github.com/Mbed-TLS/mbedtls/pull/10559, https://github.com/Mbed-TLS/mbedtls/pull/10562, TODO to fix the problems that this reveals.

## PR checklist

- [x] **TF-PSA-Crypto PR** provided # | not required because: transparent change
- [x] **development PR** provided # | not required because: transparent change
- [x] **3.6 PR** provided # | not required because: transparent change
