### PR TITLE
Use the same Python executable instead of `python`

### DIFF
--- a/scripts/make_generated_files.py
+++ b/scripts/make_generated_files.py
@@ -33,7 +33,7 @@ class GenerationScript:
 
         # Executable to run the script, needed for Windows
         if script.suffix == ".py":
-            self.exe = "python"
+            self.exe = sys.executable
         elif script.suffix == ".pl":
             self.exe = "perl"
 
@@ -62,7 +62,7 @@ def get_generation_script_files(generation_script: str):
     """
     files = []
     if generation_script.endswith(".py"):
-        cmd = ["python"]
+        cmd = [sys.executable]
     elif generation_script.endswith(".pl"):
         cmd = ["perl"]
     cmd += [generation_script, "--list"]


### PR DESCRIPTION
Fix https://github.com/Mbed-TLS/mbedtls-framework/issues/269

## PR checklist

- [x] **TF-PSA-Crypto PR** provided # | not required because: the bug doesn't affect the CI
- [x] **development PR** provided # | not required because: the bug doesn't affect the CI
- [x] **3.6 PR** provided # | not required because: the bug doesn't affect the CI
