### PR TITLE
mbedtls_pk_helpers_make_psa_key_from_predefined: don't continue on test failure

### DIFF
--- a/tests/src/pk_helpers.c
+++ b/tests/src/pk_helpers.c
@@ -94,7 +94,10 @@ mbedtls_svc_key_id_t mbedtls_pk_helpers_make_psa_key_from_predefined(psa_key_typ
     const uint8_t *key = NULL;
     size_t key_len = 0;
 
-    mbedtls_pk_helpers_get_predefined_key_data(key_type, key_bits, &key, &key_len);
+    if (mbedtls_pk_helpers_get_predefined_key_data(key_type, key_bits,
+                                                   &key, &key_len) != 0) {
+        goto exit;
+    }
 
     psa_set_key_type(&attr, key_type);
     psa_set_key_usage_flags(&attr, usage_flags);


### PR DESCRIPTION
Just a minor thing pointed out by Coverity.

## PR checklist

Please add the numbers (or links) of the associated pull requests for consuming branches. You can omit branches where this pull request is not needed.

- [x] **TF-PSA-Crypto PR** provided # | not required because: minor test improvement only
- [x] **development PR** provided # | not required because: minor test improvement only
- [x] **3.6 PR** provided # | not required because: minor test improvement only
