### PR TITLE
Teach check_names about platform requirement macros in common.h

### DIFF
--- a/scripts/check_names.py
+++ b/scripts/check_names.py
@@ -1162,6 +1162,10 @@ class NameChecker():
         return len(problems)
 
     BIGNUM_SHORTHANDS = frozenset(['biH', 'biL', 'ciH', 'ciL'])
+    PLATFORM_REQUIREMENTS_HACK_MACROS = frozenset([
+        '__DEPREC',
+        '__STDC_WANT_LIB_EXT1__',
+    ])
     def name_pattern_exception(self, group: str, match: Match) -> bool:
         """Whether the given match is an exception to normal naming patterns.
 
@@ -1174,6 +1178,13 @@ class NameChecker():
         if group == 'internal_macros' and \
            '_platform_requirements.h' in match.filename and \
            re.match(r'_[A-Z_]', match.name):
+            return True
+        # There are additional hacks in tf_psa_crypto_common.h (currently,
+        # specifically for the sake of IAR) around platform requirement
+        # macros that can't go in the intended header.
+        if group == 'internal_macros' and \
+           match.filename.endswith('/tf_psa_crypto_common.h') and \
+           match.name in self.PLATFORM_REQUIREMENTS_HACK_MACROS:
             return True
         # We use some short macros that start with a lowercase letter
         # internally in bignum code. They are grandfathered in. They


### PR DESCRIPTION
Unfortunately, for IAR, we need to mention some platform requirement macros outside of `tf_psa_crypto_platform_requirements.h`. Add an exception to `check_names.py`, because it's a lot easier than finding some generic mechanism. (`//no-check-names` doesn't help with a macro definition.)

## PR checklist

- [x] **mbedtls development PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10635
- [ ] **mbedtls 4.1 PR** TODO
- [x] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/708
- [ ] **TF-PSA-Crypto 1.1 PR** TODO
- [x] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/289; https://github.com/Mbed-TLS/mbedtls-framework/pull/299
- [x] **3.6 PR** provided https://github.com/Mbed-TLS/mbedtls/pull/10636 
- **tests**  built (but did not link) the library, the unit test support code and the unit tests (but not the programs) in the baremetal config with IAR 9.40 for Arm
