### PR TITLE
c_build_helper: Split cc command line

### DIFF
--- a/scripts/mbedtls_framework/c_build_helper.py
+++ b/scripts/mbedtls_framework/c_build_helper.py
@@ -98,7 +98,7 @@ def compile_c_file(c_filename, exe_filename, include_dirs):
     cc = os.getenv('HOSTCC', None)
     if cc is None:
         cc = os.getenv('CC', 'cc')
-    cmd = [cc]
+    cmd = cc.split()
 
     proc = subprocess.Popen(cmd,
                             stdout=subprocess.DEVNULL,


### PR DESCRIPTION
Optionally the CC/HOSTCC environment variable can hold the command to invoke the C compiler, however this command can also contain extra arguments, not only the binary name. In this particular case Python was treating the whole value as a single binary name, and was trying to execute as such (e.g. "cc -arg1 -arg2" instead of "cc" and the arguments separately), which results in failure.

Split the compiler command into its components to invoke it correctly.

## Description

In case the `CC` or `HOSTCC` environment variable contains compiler flags also (not only the compiler binary), then compilation fails, because Python treats the whole value as a single executable instead of treating it as binary + arguments. This change splits the compiler command to execute it correctly.

(This issue came up in the Yocto project, that sets compiler flags extensively - compiling mbedtls 4 due to this failed)

## PR checklist

Please add the numbers (or links) of the associated pull requests for consuming branches. You can omit branches where this pull request is not needed.

- [ ] **TF-PSA-Crypto development PR** provided # | not required because: 
- [ ] **TF-PSA-Crypto 1.1 PR** provided # | not required because: 
- [ ] **mbedtls development PR** provided # | not required because: 
- [ ] **mbedtls 4.1 PR** provided # | not required because: 
- [ ] **mbedtls 3.6 PR** provided # | not required because:

As far as I understand this issue needs to be fixed only in the main branch, and this repo is used as a submodule, and as such, its revision is fixed. The issue being fixed wasn't observed with previous version of mbedtls. But if I'm wrong, and there are other branches to be fixed, just LMK