### PR TITLE
Allow macros that shadow mldsa-native functions

### DIFF
--- a/scripts/check_names.py
+++ b/scripts/check_names.py
@@ -61,7 +61,12 @@ PUBLIC_MACRO_PATTERN = re.compile(r"^(MBEDTLS|PSA|TF_PSA_CRYPTO)_[0-9A-Z_]*[0-9A
 # implementation), must not end with an underscore (for legibility),
 # and must not consist of a single letter (because we've seen embedded
 # platforms that claim single-uppercase-letter names for themselves).
-INTERNAL_MACRO_PATTERN = re.compile("^[A-Z][0-9A-Z_]*[A-Z0-9]$")
+#
+# We make an exception for the helper macros that shadow the functions
+# declared by mldsa-native.
+INTERNAL_MACRO_PATTERN = re.compile(
+    "^([A-Z][0-9A-Z_]*[A-Z0-9]|tf_psa_crypto_pqcp_mldsa[a-zA-Z0-9_]*[a-zA-Z0-9])$"
+)
 CONSTANTS_PATTERN = PUBLIC_MACRO_PATTERN
 IDENTIFIER_PATTERN = re.compile(r"^(mbedtls|psa|tf_psa_crypto)_[0-9a-z_]*[0-9a-z]$")
 


### PR DESCRIPTION
## Description

`check_names.py` normally requires uppercase macro names. Make an exception for helper macros that shadow the functions names used by mldsa-native.

## PR checklist

- [ ] **framework PR** provided https://github.com/Mbed-TLS/mbedtls-framework/pull/305
- [ ] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/786
- [ ] **TF-PSA-Crypto 1.1 PR**  not required because: new feature work
- [ ] **mbedtls development PR**  not required because: crypto-only feature work
- [ ] **mbedtls 4.1 PR** not required because: crypto-only feature work
- [ ] **mbedtls 3.6 PR** not required because: crypto-only feature work