### PR TITLE
scripts: Add dispatch include path and new generation location

### DIFF
--- a/scripts/check-doxy-blocks.pl
+++ b/scripts/check-doxy-blocks.pl
@@ -21,6 +21,7 @@ my @tf_psa_crypto_directories = qw(include/psa include/tf-psa-crypto
                                    include/mbedtls
                                    drivers/builtin/include/mbedtls
                                    drivers/builtin/src core dispatch
+                                   dispatch/include/psa
                                    doxygen/input extras platform utilities);
 
 # very naive pattern to find directives:

--- a/scripts/check_names.py
+++ b/scripts/check_names.py
@@ -778,6 +778,7 @@ class TFPSACryptoCodeParser(CodeParser):
 
     H_PUBLIC = [
         "include/**/*.h",
+        "dispatch/include/**/*.h",
         "drivers/*/include/**/*.h",
     ]
     H_PUBLIC_EXCLUDE = [
@@ -793,6 +794,11 @@ class TFPSACryptoCodeParser(CodeParser):
         "extras/*.h",
         "platform/*.h",
         "utilities/*.h",
+    ]
+
+    H_GENERATED_EXCLUDE = [
+        "core/psa_crypto_driver_wrappers.h",
+        "dispatch/psa_crypto_driver_wrappers.h"
     ]
 
     H_TEST_DRIVERS = [
@@ -830,7 +836,7 @@ class TFPSACryptoCodeParser(CodeParser):
             self.H_PUBLIC_EXCLUDE + ["drivers/p256-m/p256-m/p256-m.h"])
         mbed_psa_words = self.parse_mbed_psa_words(
             self.H_PUBLIC + self.H_INTERNAL + self.C_INTERNAL,
-            self.H_PUBLIC_EXCLUDE + ["core/psa_crypto_driver_wrappers.h"])
+            self.H_PUBLIC_EXCLUDE + self.H_GENERATED_EXCLUDE)
         symbols = self.parse_symbols()
 
         return self._parse(all_macros, enum_consts, identifiers,

--- a/scripts/check_names.py
+++ b/scripts/check_names.py
@@ -796,11 +796,6 @@ class TFPSACryptoCodeParser(CodeParser):
         "utilities/*.h",
     ]
 
-    H_GENERATED_EXCLUDE = [
-        "core/psa_crypto_driver_wrappers.h",
-        "dispatch/psa_crypto_driver_wrappers.h"
-    ]
-
     H_TEST_DRIVERS = [
         "framework/tests/include/test/drivers/*.h",
     ]
@@ -836,7 +831,7 @@ class TFPSACryptoCodeParser(CodeParser):
             self.H_PUBLIC_EXCLUDE + ["drivers/p256-m/p256-m/p256-m.h"])
         mbed_psa_words = self.parse_mbed_psa_words(
             self.H_PUBLIC + self.H_INTERNAL + self.C_INTERNAL,
-            self.H_PUBLIC_EXCLUDE + self.H_GENERATED_EXCLUDE)
+            self.H_PUBLIC_EXCLUDE)
         symbols = self.parse_symbols()
 
         return self._parse(all_macros, enum_consts, identifiers,
@@ -969,7 +964,7 @@ class MBEDTLSCodeParser(CodeParser):
                 "library/*.c",
                 "3rdparty/everest/library/everest.c",
                 "3rdparty/everest/library/x25519.c"
-            ], ["library/psa_crypto_driver_wrappers.h"])
+            ])
         else:
             all_macros = {"public": [], "internal": [], "private":[]}
             all_macros["public"] = self.parse_macros([

--- a/scripts/make_generated_files.py
+++ b/scripts/make_generated_files.py
@@ -22,11 +22,16 @@ COMMON_GENERATION_SCRIPTS = [
 ]
 
 if build_tree.looks_like_tf_psa_crypto_root("."):
+    new_dispatch_layout = (Path.cwd() / "dispatch" / "CMakeLists.txt").exists()
+    if build_tree.tf_psa_crypto_version() >= (1,1,0) and new_dispatch_layout:
+        dispatch_prefix = Path("dispatch")
+    else:
+        dispatch_prefix = Path("core")
     TF_PSA_CRYPTO_GENERATION_SCRIPTS = [
         GenerationScript(
             Path("scripts/generate_driver_wrappers.py"),
-            [Path("core/psa_crypto_driver_wrappers.h"),
-             Path("core/psa_crypto_driver_wrappers_no_static.c")],
+            [dispatch_prefix / "psa_crypto_driver_wrappers.h",
+            dispatch_prefix / "psa_crypto_driver_wrappers_no_static.c"],
             "", None
         ),
         GenerationScript(

--- a/scripts/make_generated_files.py
+++ b/scripts/make_generated_files.py
@@ -22,16 +22,15 @@ COMMON_GENERATION_SCRIPTS = [
 ]
 
 if build_tree.looks_like_tf_psa_crypto_root("."):
-    new_dispatch_layout = (Path.cwd() / "dispatch" / "CMakeLists.txt").exists()
-    if build_tree.tf_psa_crypto_version() >= (1,1,0) and new_dispatch_layout:
-        dispatch_prefix = Path("dispatch")
+    if (Path.cwd() / "dispatch" / "CMakeLists.txt").exists():
+        DISPATCH_PREFIX = Path("dispatch")
     else:
-        dispatch_prefix = Path("core")
+        DISPATCH_PREFIX = Path("core")
     TF_PSA_CRYPTO_GENERATION_SCRIPTS = [
         GenerationScript(
             Path("scripts/generate_driver_wrappers.py"),
-            [dispatch_prefix / "psa_crypto_driver_wrappers.h",
-            dispatch_prefix / "psa_crypto_driver_wrappers_no_static.c"],
+            [DISPATCH_PREFIX / "psa_crypto_driver_wrappers.h",
+             DISPATCH_PREFIX / "psa_crypto_driver_wrappers_no_static.c"],
             "", None
         ),
         GenerationScript(

--- a/scripts/mbedtls_framework/build_tree.py
+++ b/scripts/mbedtls_framework/build_tree.py
@@ -148,3 +148,11 @@ def is_mbedtls_3_6() -> bool:
         return False
     with open(os.path.join(root, 'include', 'mbedtls', 'build_info.h'), 'r') as f:
         return re.search(r"#define MBEDTLS_VERSION_NUMBER.*0x0306", f.read()) is not None
+
+def tf_psa_crypto_version() -> tuple:
+    root = guess_project_root()
+    if not looks_like_root(root):
+        raise Exception('Neither Mbed TLS nor TF-PSA-Crypto source tree found')
+    with open(os.path.join(root, 'include', 'tf-psa-crypto', 'build_info.h'), 'r') as f:
+        m = re.search(r"#define TF_PSA_CRYPTO_VERSION_STRING.*\"([\d]+)\.([\d]+)\.([\d]+)\"", f.read())
+        return tuple(int(i) for i in m.groups())

--- a/scripts/mbedtls_framework/build_tree.py
+++ b/scripts/mbedtls_framework/build_tree.py
@@ -148,11 +148,3 @@ def is_mbedtls_3_6() -> bool:
         return False
     with open(os.path.join(root, 'include', 'mbedtls', 'build_info.h'), 'r') as f:
         return re.search(r"#define MBEDTLS_VERSION_NUMBER.*0x0306", f.read()) is not None
-
-def tf_psa_crypto_version() -> tuple:
-    root = guess_project_root()
-    if not looks_like_root(root):
-        raise Exception('Neither Mbed TLS nor TF-PSA-Crypto source tree found')
-    with open(os.path.join(root, 'include', 'tf-psa-crypto', 'build_info.h'), 'r') as f:
-        m = re.search(r"#define TF_PSA_CRYPTO_VERSION_STRING.*\"([\d]+)\.([\d]+)\.([\d]+)\"", f.read())
-        return tuple(int(i) for i in m.groups())

--- a/scripts/mbedtls_framework/psa_storage.py
+++ b/scripts/mbedtls_framework/psa_storage.py
@@ -48,12 +48,14 @@ class Expr:
         if build_tree.looks_like_root('.'):
             includes = ['include']
             if build_tree.looks_like_tf_psa_crypto_root('.'):
+                includes.append('dispatch/include')
                 includes.append('drivers/builtin/include')
                 includes.append('drivers/everest/include')
                 includes.append('drivers/everest/include/tf-psa-crypto/private/')
                 includes.append('drivers/pqcp/include')
             elif not build_tree.is_mbedtls_3_6():
                 includes.append('tf-psa-crypto/include')
+                includes.append('tf-psa-crypto/dispatch/include')
                 includes.append('tf-psa-crypto/drivers/builtin/include')
                 includes.append('tf-psa-crypto/drivers/everest/include')
                 includes.append('tf-psa-crypto/drivers/everest/include/tf-psa-crypto/private/')

--- a/scripts/test_psa_constant_names.py
+++ b/scripts/test_psa_constant_names.py
@@ -171,6 +171,7 @@ def main():
     else:
         parser.add_argument('--include', '-I',
                             action='append', default=['tf-psa-crypto/include',
+                                                      'tf-psa-crypto/dispatch/include',
                                                       'tf-psa-crypto/drivers/builtin/include',
                                                       'tf-psa-crypto/drivers/everest/include',
                                                       'tf-psa-crypto/drivers/everest/include/' +


### PR DESCRIPTION
## Description

PSA crypto driver dispatch files are generated into `dispatch/` instead of `core/` in newer TF-PSA-Crypto versions. API headers that rely on driver and dispatch implementation details are also moved from `include/` to `dispatch/include/`.

Update the framework scripts to work with both the old and new layouts.

## PR checklist

- [x] **TF-PSA-Crypto development PR** provided Mbed-TLS/TF-PSA-Crypto#809
- [x] **TF-PSA-Crypto 1.1 PR** not required because: not a bugfix, repository structure change is not entirely backwards compatible
- [x] **mbedtls development PR** provided Mbed-TLS/mbedtls#10780
- [x] **mbedtls 4.1 PR** not required because: does not affect mbedtls
- [x] **mbedtls 3.6 PR** not required because: does not affect mbedtls
