### PR TITLE
Framework to measure stack usage

### DIFF
--- a/tests/include/test/stack_usage.h
+++ b/tests/include/test/stack_usage.h
@@ -1,0 +1,173 @@
+/** A framework to measure stack usage of a code snippet.
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#ifndef TEST_STACK_USAGE_H
+#define TEST_STACK_USAGE_H
+
+#include "test/helpers.h"
+
+#undef MBEDTLS_TEST_STACK_USAGE
+
+/* Don't break the build if <alloca.h> is not available. */
+#if defined(__has_include)
+#if __has_include(<alloca.h>)
+#define MBEDTLS_TEST_STACK_USAGE_ALLOCA
+#define MBEDTLS_TEST_STACK_USAGE
+#endif
+#endif
+
+/* The stack usage measurement code works with MemorySanitizer (MSan).
+ * However, MSan induces considerable overhead to the stack usage
+ * (more than double), so doing measurements with MSan is generally not
+ * useful. Hence we disable stack usage measurement when building with MSan. */
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+#undef MBEDTLS_TEST_STACK_USAGE_ALLOCA
+#undef MBEDTLS_TEST_STACK_USAGE
+#endif
+#endif
+
+#if defined(MBEDTLS_TEST_STACK_USAGE)
+
+/** Prepare to measure the stack usage of subsequent code.
+ *
+ * This function may temporarily grow the actually allocated stack space
+ * by approximately \p max bytes.
+ *
+ * After calling this function:
+ * - You may call mbedtls_test_stack_usage_get() from the same function
+ *   one or more times to get the maximum stack usage since the call to
+ *   mbedtls_test_stack_usage_start().
+ * - You must call mbedtls_test_stack_usage_stop() from the same function.
+ *
+ * \param max       The number of bytes that should be measurable.
+ *                  If the subsequent code uses more than \p max bytes
+ *                  of stack space, mbedtls_test_stack_usage_get()
+ *                  may not be able to measure the stack usage accurately.
+ *
+ * \retval #PSA_SUCCESS
+ *                  Success.
+ * \retval #PSA_ERROR_NOT_SUPPORTED
+ *                  The stack usage framework doesn't work in this
+ *                  environment.
+ * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
+ *                  This implementation of stack usage measurement needs
+ *                  to actually allocate memory, and the memory allocation
+ *                  failed.
+ */
+int mbedtls_test_stack_usage_start(size_t max);
+
+/** .
+ *
+ * \return          The largest stack depth since the previous call to
+ *                  mbedtls_test_stack_usage_start(), not including the
+ *                  part of the stack above the call to
+ *                  mbedtls_test_stack_usage_start().
+ *
+ *                  The value is approximate. It may be rounded to a multiple
+ *                  of 16, and does not account for the (small but nonzero)
+ *                  stack space used by mbedtls_test_stack_usage_start().
+ *
+ *                  This function may return \c SIZE_MAX if the used stack
+ *                  space is larger than approximately the \c max value
+ *                  passed to mbedtls_test_stack_usage_start(), or if
+ *                  mbedtls_test_stack_usage_start() has not been called
+ *                  in this thread since the last call to
+ *                  mbedtls_test_stack_usage_stop().
+ */
+size_t mbedtls_test_stack_usage_get(void);
+
+/** Assert a bound on stack usage since the last call to
+ * mbedtls_test_stack_usage_start().
+ *
+ * If the largest stack depth is more than \p limit, mark the test case
+ * as failed and jump to the \c exit label.
+ *
+ * See mbedtls_test_stack_usage_get() for caveats regarding precision.
+ *
+ * \param limit     The number of bytes of stack space that may have been used.
+ */
+#define MBEDTLS_TEST_STACK_USAGE_CHECK(limit) \
+    TEST_LE_U(mbedtls_test_stack_usage_get(), limit)
+
+/** Stop stack measurement.
+ *
+ * You must call this function after calling mbedtls_test_stack_usage_start(),
+ * from the same stack frame.
+ *
+ * This function does nothing if there has not been a previous call to
+ * mbedtls_test_stack_usage_start().
+ */
+void mbedtls_test_stack_usage_stop(void);
+
+#else /* MBEDTLS_TEST_STACK_USAGE */
+
+static inline int mbedtls_test_stack_usage_start(size_t max)
+{
+    (void) max;
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+#define MBEDTLS_TEST_STACK_USAGE_CHECK(limit) ((void) 0)
+
+static inline void mbedtls_test_stack_usage_stop(void)
+{
+    /* nothing to do */
+}
+
+#endif /* MBEDTLS_TEST_STACK_USAGE */
+
+/** Prepare to measure the stack usage of subsequent code.
+ *
+ * This function may temporarily grow the actually allocated stack space
+ * by approximately \p max bytes.
+ *
+ * After calling this macro:
+ * - You may call #MBEDTLS_TEST_STACK_USAGE_CHECK() from the same function
+ *   one or more times to get the maximum stack usage since the call to
+ *   MBEDTLS_TEST_STACK_USAGE_START().
+ * - You must call MBEDTLS_TEST_STACK_USAGE_STOP() from the same function.
+ *
+ * If the stack usage framework doesn't work, mark the test case as failed
+ * and jump to the \c exit label.
+ *
+ * \param max       The number of bytes that should be measurable.
+ */
+#define MBEDTLS_TEST_STACK_USAGE_START(max)             \
+    PSA_ASSERT(mbedtls_test_stack_usage_start(max))
+
+/** Prepare to measure the stack usage of subsequent code.
+ *
+ * This function may temporarily grow the actually allocated stack space
+ * by approximately \p max bytes.
+ *
+ * After calling this macro:
+ * - You may call #MBEDTLS_TEST_STACK_USAGE_CHECK() from the same function
+ *   one or more times to get the maximum stack usage since the call to
+ *   MBEDTLS_TEST_STACK_USAGE_START().
+ * - You must call MBEDTLS_TEST_STACK_USAGE_STOP() from the same function.
+ *
+ * If the stack usage framework doesn't work, mark the test case as skipped
+ * and jump to the \c exit label.
+ *
+ * \param max       The number of bytes that should be measurable.
+ */
+#define MBEDTLS_TEST_STACK_USAGE_TRY(max)               \
+    TEST_ASSUME(mbedtls_test_stack_usage_start(max) == PSA_SUCCESS)
+
+/** Stop stack measurement.
+ *
+ * You must call this macro after calling #MBEDTLS_TEST_STACK_USAGE_START()
+ * or #MBEDTLS_TEST_STACK_USAGE_TRY(), from the same stack frame.
+ *
+ * This function does nothing if there has not been a previous call to
+ * mbedtls_test_stack_usage_start().
+ */
+#define MBEDTLS_TEST_STACK_USAGE_STOP(max)      \
+    mbedtls_test_stack_usage_stop()
+
+#endif /* TEST_STACK_USAGE_H */

--- a/tests/src/stack_usage.c
+++ b/tests/src/stack_usage.c
@@ -1,0 +1,137 @@
+/** \file stack_usage.c
+ *
+ * \brief A framework to measure stack usage of a code snippet.
+ *
+ * This framework is only implemented on specific platforms,
+ * and only makes approximate measurements.
+ */
+
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+#include "test_common.h"
+#include <test/helpers.h>
+#include <test/macros.h>
+#include <test/stack_usage.h>
+
+
+#if defined(MBEDTLS_TEST_STACK_USAGE_ALLOCA)
+
+#include <alloca.h>
+#include <test/random.h>
+
+/* The stack usage check involves reading memory which is uninitialized
+ * by the rules of C. If necessary, tell sanitizers that it's ok. */
+#undef MAKE_MEMORY_DEFINED
+
+#if defined(__has_include)
+#if __has_include(<valgrind/memcheck.h>)
+#include <valgrind/memcheck.h>
+#define MAKE_MEMORY_DEFINED(start, len) VALGRIND_MAKE_MEM_DEFINED(start, len)
+#endif
+#endif
+
+#if !defined(MAKE_MEMORY_DEFINED)
+#define MAKE_MEMORY_DEFINED(start, len) ((void) 0)
+#endif
+
+/* Length of the pattern written repeatedly to the stack to detect the
+ * unchanged region. This should be a power of 2, large enough so that
+ * a random string of this length is statistically unique. The stack usage
+ * figure is rounded to a multiple of this length, so it should be small
+ * to get more precise measurements. */
+#define PATTERN_LENGTH 16
+
+/* A pattern written repeatedly to the stack to detect the unchanged region. */
+static unsigned char pattern[PATTERN_LENGTH];
+
+/* Starting (i.e. lowest) address of the stack region that has been filled
+ * with the pattern. It will be aligned to PATTERN_LENGTH.
+ *
+ * 0 when no marking has been done.
+ */
+static uintptr_t marked_start;
+
+/* Length of the stack region that has been filled with the pattern.
+ * It will be a multiple of PATTERN_LENGTH.
+ *
+ * 0 when no marking has been done.
+ */
+static size_t marked_size;
+
+/* Fill approximately max bytes on the stack with a random pattern.
+ * The filled region is aligned and rounded to a multiple of PATTERN_LENGTH.
+ *
+ * Later, we can tell how much of the stack has remained unused by
+ * checking where the pattern is still present.
+ */
+int mbedtls_test_stack_usage_start(size_t max)
+{
+    /* Generate a random pattern, which is statistically guaranteed
+     * to be distinct from all other program data. */
+    mbedtls_test_rnd_std_rand(NULL, pattern, PATTERN_LENGTH);
+
+    /* Align the start and size of the marked region to multiples
+     * of PATTERN_LENGTH. This simplifies filling with the pattern,
+     * and later searching for the pattern. */
+    if (max % PATTERN_LENGTH != 0) {
+        max += PATTERN_LENGTH - max % PATTERN_LENGTH;
+    }
+    unsigned char *marking = alloca(max + PATTERN_LENGTH - 1);
+    if (marking == NULL) {
+        return PSA_ERROR_INSUFFICIENT_MEMORY;
+    }
+    marked_start = (uintptr_t) marking;
+    if (marked_start % PATTERN_LENGTH != 0) {
+        marked_start += PATTERN_LENGTH - marked_start % PATTERN_LENGTH;
+        marking = (unsigned char *) marked_start;
+    }
+    marked_size = max;
+
+    for (size_t i = 0; i < marked_size; i += PATTERN_LENGTH) {
+        memcpy(marking + i, pattern, PATTERN_LENGTH);
+    }
+    return PSA_SUCCESS;
+}
+
+/* Detect how much of the region marked by mbedtls_test_stack_usage_start()
+ * is still intact, i.e. how much of the stack has remained unused. */
+size_t mbedtls_test_stack_usage_get(void)
+{
+    if (marked_start == 0 || marked_size == 0) {
+        /* Misuse. */
+        return SIZE_MAX;
+    }
+
+    /* We assume a downward-growing stack, so the unchanged part
+     * is at low addresses. If this code runs on a platform with
+     * an upward-growing stack, this function will in practice
+     * always believe that the whole marked region was overwritten.
+     */
+    const unsigned char *p = (const unsigned char *) marked_start;
+    MAKE_MEMORY_DEFINED(p, marked_size);
+
+    if (memcmp(pattern, p, PATTERN_LENGTH)) {
+        /* None of the marked region was preserved, so we have no
+         * way to bound the amount of stack that was used. */
+        return SIZE_MAX;
+    }
+
+    for (size_t i = PATTERN_LENGTH; i < marked_size; i += PATTERN_LENGTH) {
+        if (memcmp(pattern, p + i, PATTERN_LENGTH)) {
+            return marked_size - i;
+        }
+    }
+    return 0;
+}
+
+void mbedtls_test_stack_usage_stop(void)
+{
+    memset(pattern, 0, PATTERN_LENGTH);
+    marked_start = 0;
+    marked_size = 0;
+}
+
+#endif /* MBEDTLS_TEST_STACK_USAGE_ALLOCA */

--- a/tests/src/stack_usage.c
+++ b/tests/src/stack_usage.c
@@ -19,6 +19,10 @@
 
 #if defined(MBEDTLS_TEST_STACK_USAGE_ALLOCA)
 
+/* For PSA error codes (in 3.6, they may otherwise not be defined yet) */
+#include <psa/crypto_types.h>
+#include <psa/crypto_values.h>
+
 #include <alloca.h>
 #include <test/random.h>
 


### PR DESCRIPTION
Measure the stack usage of a code snippet. The new macro `MBEDTLS_TEST_STACK_USAGE_CHECK()` allows test code to assert that no more than N bytes of stack have been used.

Written for https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/889 . This isn't usable in practice: the expected stack usage varies too much depending on the target CPU, the compiler and compiler options.

## PR checklist

- [x] **TF-PSA-Crypto development PR** provided https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/886
- [x] **TF-PSA-Crypto 1.1 PR** not required because: new feature only used in crypto development
- [x] **mbedtls development PR** not required because: new feature only used in crypto development
- [x] **mbedtls 4.1 PR** not required because: new feature only used in crypto development
- [x] **mbedtls 3.6 PR** not required because: new feature only used in crypto development
